### PR TITLE
Updated the version enums

### DIFF
--- a/MtconnectCore/MtconnectCore.csproj
+++ b/MtconnectCore/MtconnectCore.csproj
@@ -20,7 +20,7 @@
     <PackageReleaseNotes>Changed the methodology for producing validation results. Errors were no longer bubbling up to the root document.</PackageReleaseNotes>
     <AssemblyVersion></AssemblyVersion>
     <FileVersion></FileVersion>
-    <Version>2.1.0.1</Version>
+    <Version>2.1.0.2</Version>
   </PropertyGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)'=='net45'">

--- a/MtconnectCore/MtconnectCore.xml
+++ b/MtconnectCore/MtconnectCore.xml
@@ -6637,9 +6637,7 @@
             <remarks>Prepared on: March 31, 2018</remarks>
         </member>
         <member name="F:MtconnectCore.Standard.Contracts.Enums.MtconnectVersions.V_1_4_1">
-            <summary>
-            Version 1.4.1
-            </summary>
+            <inheritdoc cref="F:MtconnectCore.Standard.Contracts.Enums.MtconnectVersions.V_1_4_0"/>
         </member>
         <member name="F:MtconnectCore.Standard.Contracts.Enums.MtconnectVersions.V_1_5_0">
             <summary>
@@ -6647,9 +6645,7 @@
             </summary>
         </member>
         <member name="F:MtconnectCore.Standard.Contracts.Enums.MtconnectVersions.V_1_5_1">
-            <summary>
-            Version 1.5.1
-            </summary>
+            <inheritdoc cref="F:MtconnectCore.Standard.Contracts.Enums.MtconnectVersions.V_1_5_0"/>
         </member>
         <member name="F:MtconnectCore.Standard.Contracts.Enums.MtconnectVersions.V_1_6_0">
             <summary>
@@ -6658,9 +6654,7 @@
             <remarks>Prepared on: July 15, 2020</remarks>
         </member>
         <member name="F:MtconnectCore.Standard.Contracts.Enums.MtconnectVersions.V_1_6_1">
-            <summary>
-            Version 1.6.1
-            </summary>
+            <inheritdoc cref="F:MtconnectCore.Standard.Contracts.Enums.MtconnectVersions.V_1_6_0"/>
         </member>
         <member name="F:MtconnectCore.Standard.Contracts.Enums.MtconnectVersions.V_1_7_0">
             <summary>
@@ -6669,9 +6663,7 @@
             <remarks>Prepared on: February 25, 2021</remarks>
         </member>
         <member name="F:MtconnectCore.Standard.Contracts.Enums.MtconnectVersions.V_1_7_1">
-            <summary>
-            Version 1.7.1
-            </summary>
+            <inheritdoc cref="F:MtconnectCore.Standard.Contracts.Enums.MtconnectVersions.V_1_7_0"/>
         </member>
         <member name="F:MtconnectCore.Standard.Contracts.Enums.MtconnectVersions.V_1_8_0">
             <summary>
@@ -6679,17 +6671,26 @@
             </summary>
             <remarks>Prepared on: September 6, 2021</remarks>
         </member>
+        <member name="F:MtconnectCore.Standard.Contracts.Enums.MtconnectVersions.V_1_8_1">
+            <inheritdoc cref="F:MtconnectCore.Standard.Contracts.Enums.MtconnectVersions.V_1_8_0"/>
+        </member>
         <member name="F:MtconnectCore.Standard.Contracts.Enums.MtconnectVersions.V_2_0_0">
             <summary>
             Version 2.0.0
             </summary>
             <remarks>Prepared on: May 24, 2022</remarks>
         </member>
+        <member name="F:MtconnectCore.Standard.Contracts.Enums.MtconnectVersions.V_2_0_1">
+            <inheritdoc cref="F:MtconnectCore.Standard.Contracts.Enums.MtconnectVersions.V_2_0_0"/>
+        </member>
         <member name="F:MtconnectCore.Standard.Contracts.Enums.MtconnectVersions.V_2_1_0">
             <summary>
             Version 2.1.0
             </summary>
             <remarks>Prepared on: January 14, 2023</remarks>
+        </member>
+        <member name="F:MtconnectCore.Standard.Contracts.Enums.MtconnectVersions.V_2_1_1">
+            <inheritdoc cref="F:MtconnectCore.Standard.Contracts.Enums.MtconnectVersions.V_2_1_0"/>
         </member>
         <member name="F:MtconnectCore.Standard.Contracts.Enums.MtconnectVersions.V_2_2_0">
             <summary>
@@ -7965,6 +7966,9 @@
             <param name="nsmgr"></param>
             <param name="defaultNamespace"></param>
             <param name="version"></param>
+        </member>
+        <member name="F:MtconnectCore.Standard.Contracts.VersionHelper.versionMinimumVersion">
+            <remarks>Find this in the <c>MTConnectDevices_x.x.xsd</c> referenced at <c>/xs:schema[@vs:minVersion]</c></remarks>
         </member>
         <member name="P:MtconnectCore.Standard.CurrentRequestQuery.Path">
             <summary>

--- a/MtconnectCore/Standard/Contracts/Enums/MtconnectVersions.cs
+++ b/MtconnectCore/Standard/Contracts/Enums/MtconnectVersions.cs
@@ -35,55 +35,53 @@
         /// </summary>
         /// <remarks>Prepared on: March 31, 2018</remarks>
         V_1_4_0 = 1 << 5,
-        /// <summary>
-        /// Version 1.4.1
-        /// </summary>
+        /// <inheritdoc cref="V_1_4_0"/>
         V_1_4_1 = 1 << 6,
         /// <summary>
         /// Version 1.5.0
         /// </summary>
         V_1_5_0 = 1 << 7,
-        /// <summary>
-        /// Version 1.5.1
-        /// </summary>
+        /// <inheritdoc cref="V_1_5_0"/>
         V_1_5_1 = 1 << 8,
         /// <summary>
         /// Version 1.6.0
         /// </summary>
         /// <remarks>Prepared on: July 15, 2020</remarks>
         V_1_6_0 = 1 << 9,
-        /// <summary>
-        /// Version 1.6.1
-        /// </summary>
+        /// <inheritdoc cref="V_1_6_0"/>
         V_1_6_1 = 1 << 10,
         /// <summary>
         /// Version 1.7.0
         /// </summary>
         /// <remarks>Prepared on: February 25, 2021</remarks>
         V_1_7_0 = 1 << 11,
-        /// <summary>
-        /// Version 1.7.1
-        /// </summary>
+        /// <inheritdoc cref="V_1_7_0"/>
         V_1_7_1 = 1 << 12,
         /// <summary>
         /// Version 1.8.0
         /// </summary>
         /// <remarks>Prepared on: September 6, 2021</remarks>
         V_1_8_0 = 1 << 13,
+        /// <inheritdoc cref="V_1_8_0"/>
+        V_1_8_1 = 1 << 14,
         /// <summary>
         /// Version 2.0.0
         /// </summary>
         /// <remarks>Prepared on: May 24, 2022</remarks>
-        V_2_0_0 = 1 << 14,
+        V_2_0_0 = 1 << 15,
+        /// <inheritdoc cref="V_2_0_0"/>
+        V_2_0_1 = 1 << 16,
         /// <summary>
         /// Version 2.1.0
         /// </summary>
         /// <remarks>Prepared on: January 14, 2023</remarks>
-        V_2_1_0 = 1 << 15,
+        V_2_1_0 = 1 << 17,
+        /// <inheritdoc cref="V_2_1_0"/>
+        V_2_1_1 = 1 << 18,
         /// <summary>
         /// Version 2.2.0
         /// </summary>
         /// <remarks>Pre-Release</remarks>
-        V_2_2_0 = 1 << 16,
+        V_2_2_0 = 1 << 19,
     }
 }

--- a/MtconnectCore/Standard/Contracts/VersionHelper.cs
+++ b/MtconnectCore/Standard/Contracts/VersionHelper.cs
@@ -24,6 +24,14 @@ namespace MtconnectCore.Standard.Contracts
             { MtconnectVersions.V_1_6_0, "1.6.0" },
             { MtconnectVersions.V_1_6_1, "1.6.1" },
             { MtconnectVersions.V_1_7_0, "1.7.0" },
+            { MtconnectVersions.V_1_7_1, "1.7.1" },
+            { MtconnectVersions.V_1_8_0, "1.8.0" },
+            { MtconnectVersions.V_1_8_1, "1.8.1" },
+            { MtconnectVersions.V_2_0_0, "2.0.0" },
+            { MtconnectVersions.V_2_0_1, "2.0.1" },
+            { MtconnectVersions.V_2_1_0, "2.1.0" },
+            { MtconnectVersions.V_2_1_1, "2.1.1" },
+            { MtconnectVersions.V_2_2_0, "2.2.0" }
         };
 
         private static Dictionary<MtconnectVersions, DateTime> versionReleaseDate = new Dictionary<MtconnectVersions, DateTime>() {
@@ -39,8 +47,16 @@ namespace MtconnectCore.Standard.Contracts
             { MtconnectVersions.V_1_6_0, new DateTime(2020, 07, 15) },
             { MtconnectVersions.V_1_6_1, new DateTime(2020, 07, 15) },
             { MtconnectVersions.V_1_7_0, new DateTime(2021, 02, 25) },
+            { MtconnectVersions.V_1_7_1, new DateTime(2021, 02, 25) },
+            { MtconnectVersions.V_1_8_0, new DateTime(2021, 09, 06) },
+            { MtconnectVersions.V_1_8_1, new DateTime(2021, 09, 06) },
+            { MtconnectVersions.V_2_0_0, new DateTime(2022, 05, 24) },
+            { MtconnectVersions.V_2_0_1, new DateTime(2022, 05, 24) },
+            { MtconnectVersions.V_2_1_0, new DateTime(2023, 01, 14) },
+            { MtconnectVersions.V_2_1_1, new DateTime(2023, 01, 14) },
         };
 
+        /// <remarks>Find this in the <c>MTConnectDevices_x.x.xsd</c> referenced at <c>/xs:schema[@vs:minVersion]</c></remarks>
         private static Dictionary<MtconnectVersions, MtconnectVersions?> versionMinimumVersion = new Dictionary<MtconnectVersions, MtconnectVersions?>() {
              { MtconnectVersions.V_1_0_1, null },
              { MtconnectVersions.V_1_1_0, null },
@@ -54,11 +70,18 @@ namespace MtconnectCore.Standard.Contracts
              { MtconnectVersions.V_1_6_0, MtconnectVersions.V_1_1_0 },
              { MtconnectVersions.V_1_6_1, null }, // Missing vc:minVersion??? See https://github.com/mtconnect/schema/issues/10
              { MtconnectVersions.V_1_7_0, MtconnectVersions.V_1_1_0 },
+             { MtconnectVersions.V_1_7_1, null },
+             { MtconnectVersions.V_1_8_0, MtconnectVersions.V_1_1_0 },
+             { MtconnectVersions.V_1_8_1, null },
+             { MtconnectVersions.V_2_0_0, MtconnectVersions.V_1_1_0 },
+             { MtconnectVersions.V_2_0_1, null },
+             { MtconnectVersions.V_2_1_0, MtconnectVersions.V_1_1_0 },
+             { MtconnectVersions.V_2_1_1, null },
         };
 
         public static string ToName(this MtconnectVersions version) => versionNames[version];
 
-        public static MtconnectVersions? GetVersion(string version) => versionNames.Where(o => version.Contains(o.Value) || o.Value.Contains(version)).Select(o => o.Key).FirstOrDefault();
+        public static MtconnectVersions? GetVersion(string version) => versionNames.Where(o => version.Contains(o.Value) || o.Value.StartsWith(version)).Select(o => o.Key).FirstOrDefault();
 
         public static DateTime GetReleaseDate(this MtconnectVersions version) => versionReleaseDate[version];
 
@@ -187,6 +210,54 @@ namespace MtconnectCore.Standard.Contracts
                     nsmgr.AddNamespace("vc", "http://www.w3.org/2007/XMLSchema-versioning");
                     nsmgr.AddNamespace("xlink", "http://www.w3.org/1999/xlink");
                     break;
+                case MtconnectVersions.V_1_7_1:
+                    //nsmgr.AddNamespace(defaultNamespace, $"urn:mtconnect.org:{mtconnectNamespace}:1.7");
+                    nsmgr.AddNamespace(defaultNamespace, xDoc.DocumentElement.GetAttribute("xmlns"));
+                    // Missing vc:minVersion??? See https://github.com/mtconnect/schema/issues/10
+                    nsmgr.AddNamespace("xlink", "http://www.w3.org/1999/xlink");
+                    break;
+                case MtconnectVersions.V_1_8_0:
+                    //nsmgr.AddNamespace(defaultNamespace, $"urn:mtconnect.org:{mtconnectNamespace}:1.8");
+                    nsmgr.AddNamespace(defaultNamespace, xDoc.DocumentElement.GetAttribute("xmlns"));
+                    nsmgr.AddNamespace("vc", "http://www.w3.org/2007/XMLSchema-versioning");
+                    nsmgr.AddNamespace("xlink", "http://www.w3.org/1999/xlink");
+                    break;
+                case MtconnectVersions.V_1_8_1:
+                    //nsmgr.AddNamespace(defaultNamespace, $"urn:mtconnect.org:{mtconnectNamespace}:1.8");
+                    nsmgr.AddNamespace(defaultNamespace, xDoc.DocumentElement.GetAttribute("xmlns"));
+                    // Missing vc:minVersion??? See https://github.com/mtconnect/schema/issues/10
+                    nsmgr.AddNamespace("xlink", "http://www.w3.org/1999/xlink");
+                    break;
+                case MtconnectVersions.V_2_0_0:
+                    //nsmgr.AddNamespace(defaultNamespace, $"urn:mtconnect.org:{mtconnectNamespace}:2.0");
+                    nsmgr.AddNamespace(defaultNamespace, xDoc.DocumentElement.GetAttribute("xmlns"));
+                    nsmgr.AddNamespace("vc", "http://www.w3.org/2007/XMLSchema-versioning");
+                    nsmgr.AddNamespace("xlink", "http://www.w3.org/1999/xlink");
+                    break;
+                case MtconnectVersions.V_2_0_1:
+                    //nsmgr.AddNamespace(defaultNamespace, $"urn:mtconnect.org:{mtconnectNamespace}:2.0");
+                    nsmgr.AddNamespace(defaultNamespace, xDoc.DocumentElement.GetAttribute("xmlns"));
+                    // Missing vc:minVersion??? See https://github.com/mtconnect/schema/issues/10
+                    nsmgr.AddNamespace("xlink", "http://www.w3.org/1999/xlink");
+                    break;
+                case MtconnectVersions.V_2_1_0:
+                    //nsmgr.AddNamespace(defaultNamespace, $"urn:mtconnect.org:{mtconnectNamespace}:2.1");
+                    nsmgr.AddNamespace(defaultNamespace, xDoc.DocumentElement.GetAttribute("xmlns"));
+                    nsmgr.AddNamespace("vc", "http://www.w3.org/2007/XMLSchema-versioning");
+                    nsmgr.AddNamespace("xlink", "http://www.w3.org/1999/xlink");
+                    break;
+                case MtconnectVersions.V_2_1_1:
+                    //nsmgr.AddNamespace(defaultNamespace, $"urn:mtconnect.org:{mtconnectNamespace}:2.1");
+                    nsmgr.AddNamespace(defaultNamespace, xDoc.DocumentElement.GetAttribute("xmlns"));
+                    // Missing vc:minVersion??? See https://github.com/mtconnect/schema/issues/10
+                    nsmgr.AddNamespace("xlink", "http://www.w3.org/1999/xlink");
+                    break;
+                case MtconnectVersions.V_2_2_0:
+                    //nsmgr.AddNamespace(defaultNamespace, $"urn:mtconnect.org:{mtconnectNamespace}:2.2");
+                    nsmgr.AddNamespace(defaultNamespace, xDoc.DocumentElement.GetAttribute("xmlns"));
+                    nsmgr.AddNamespace("vc", "http://www.w3.org/2007/XMLSchema-versioning");
+                    nsmgr.AddNamespace("xlink", "http://www.w3.org/1999/xlink");
+                    break;
                 default:
                     break;
             }
@@ -252,6 +323,30 @@ namespace MtconnectCore.Standard.Contracts
                     break;
                 case MtconnectVersions.V_1_7_0:
                     nsmgr.AddNamespace("m", "urn:mtconnect.org:MTConnectStreams:1.7");
+                    break;
+                case MtconnectVersions.V_1_7_1:
+                    nsmgr.AddNamespace("m", "urn:mtconnect.org:MTConnectStreams:1.7");
+                    break;
+                case MtconnectVersions.V_1_8_0:
+                    nsmgr.AddNamespace("m", "urn:mtconnect.org:MTConnectStreams:1.8");
+                    break;
+                case MtconnectVersions.V_1_8_1:
+                    nsmgr.AddNamespace("m", "urn:mtconnect.org:MTConnectStreams:1.8");
+                    break;
+                case MtconnectVersions.V_2_0_0:
+                    nsmgr.AddNamespace("m", "urn:mtconnect.org:MTConnectStreams:2.0");
+                    break;
+                case MtconnectVersions.V_2_0_1:
+                    nsmgr.AddNamespace("m", "urn:mtconnect.org:MTConnectStreams:2.0");
+                    break;
+                case MtconnectVersions.V_2_1_0:
+                    nsmgr.AddNamespace("m", "urn:mtconnect.org:MTConnectStreams:2.1");
+                    break;
+                case MtconnectVersions.V_2_1_1:
+                    nsmgr.AddNamespace("m", "urn:mtconnect.org:MTConnectStreams:2.1");
+                    break;
+                case MtconnectVersions.V_2_2_0:
+                    nsmgr.AddNamespace("m", "urn:mtconnect.org:MTConnectStreams:2.2");
                     break;
                 default:
                     break;


### PR DESCRIPTION
Forgot to include updates to the Version enums, so Response Documents 1.8+ were not being identified appropriately.