### PR TITLE
Sub-Type Validation

### DIFF
--- a/MtconnectCore/MtconnectCore.xml
+++ b/MtconnectCore/MtconnectCore.xml
@@ -257,6 +257,16 @@
             <param name="documentVersion">Reference to the version of MTConnect implemented in the Response Document.</param>
             <returns>Flag for whether the MTConnect Response Document version matches with the specified <see cref="P:MtconnectCore.Standard.Contracts.Attributes.MtconnectVersionApplicabilityAttribute.MinimumVersion"/> according to the <see cref="!:ComparisonType"/>.</returns>
         </member>
+        <member name="T:MtconnectCore.Standard.Contracts.Attributes.ObservationalSubTypeAttribute">
+            <summary>
+            An attribute used to indicate that an enum value that represents an observational type also has relevant sub-type(s).
+            </summary>
+        </member>
+        <member name="P:MtconnectCore.Standard.Contracts.Attributes.ObservationalSubTypeAttribute.SubTypeEnum">
+            <summary>
+            Reference to the enum for the subtype.
+            </summary>
+        </member>
         <member name="M:MtconnectCore.Standard.Contracts.EnumHelper.Enumify(System.String)">
             <summary>
             Translates a raw string into its enum-safe equivelant.
@@ -8892,11 +8902,20 @@
         <member name="P:MtconnectCore.Standard.Documents.Devices.DataItem.SampleRate">
             <inheritdoc cref="F:MtconnectCore.Standard.Contracts.Enums.Devices.Attributes.DataItemAttributes.SAMPLE_RATE"/>
         </member>
+        <member name="P:MtconnectCore.Standard.Documents.Devices.DataItem.Source">
+            <inheritdoc cref="F:MtconnectCore.Standard.Contracts.Enums.Devices.Elements.DataItemElements.SOURCE"/>
+        </member>
         <member name="P:MtconnectCore.Standard.Documents.Devices.DataItem.Constraints">
             <inheritdoc cref="F:MtconnectCore.Standard.Contracts.Enums.Devices.Elements.DataItemElements.CONSTRAINTS"/>
         </member>
         <member name="P:MtconnectCore.Standard.Documents.Devices.DataItem.Filters">
             <inheritdoc cref="F:MtconnectCore.Standard.Contracts.Enums.Devices.Elements.DataItemElements.FILTERS"/>
+        </member>
+        <member name="P:MtconnectCore.Standard.Documents.Devices.DataItem.InitialValue">
+            <inheritdoc cref="F:MtconnectCore.Standard.Contracts.Enums.Devices.Elements.DataItemElements.INITIAL_VALUE"/>
+        </member>
+        <member name="P:MtconnectCore.Standard.Documents.Devices.DataItem.ResetTrigger">
+            <inheritdoc cref="F:MtconnectCore.Standard.Contracts.Enums.Devices.Elements.DataItemElements.RESET_TRIGGER"/>
         </member>
         <member name="M:MtconnectCore.Standard.Documents.Devices.DataItem.#ctor">
             <inheritdoc/>

--- a/MtconnectCore/Standard/Contracts/Attributes/ObservationalSubTypeAttribute.cs
+++ b/MtconnectCore/Standard/Contracts/Attributes/ObservationalSubTypeAttribute.cs
@@ -1,0 +1,21 @@
+﻿using System;
+
+namespace MtconnectCore.Standard.Contracts.Attributes
+{
+    /// <summary>
+    /// An attribute used to indicate that an enum value that represents an observational type also has relevant sub-type(s).
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Field, AllowMultiple = false, Inherited = false)]
+    public class ObservationalSubTypeAttribute : Attribute
+    {
+        /// <summary>
+        /// Reference to the enum for the subtype.
+        /// </summary>
+        public Type SubTypeEnum { get; set; }
+
+        public ObservationalSubTypeAttribute(Type subTypeEnum)
+        {
+            SubTypeEnum = subTypeEnum;
+        }
+    }
+}

--- a/MtconnectCore/Standard/Contracts/Enums/Devices/DataItemTypes/EventTypes.cs
+++ b/MtconnectCore/Standard/Contracts/Enums/Devices/DataItemTypes/EventTypes.cs
@@ -51,6 +51,7 @@ namespace MtconnectCore.Standard.Contracts.Enums.Devices.DataItemTypes
 		﻿/// {{def(EventEnum:AXIS_FEEDRATE_OVERRIDE)}}
 		/// </summary>
 		[MtconnectVersionApplicability(MtconnectVersions.V_1_3_0, "https://model.mtconnect.org/")]
+		[ObservationalSubType(typeof(AxisFeedrateOverrideSubTypes))]
 		AXIS_FEEDRATE_OVERRIDE,
 		/// <summary>
 		﻿/// {{def(EventEnum:AXIS_INTERLOCK)}}
@@ -76,6 +77,7 @@ namespace MtconnectCore.Standard.Contracts.Enums.Devices.DataItemTypes
 		﻿/// {{def(EventEnum:CHUCK_INTERLOCK)}}
 		/// </summary>
 		[MtconnectVersionApplicability(MtconnectVersions.V_1_3_0, "https://model.mtconnect.org/")]
+		[ObservationalSubType(typeof(ChuckInterlockSubTypes))]
 		CHUCK_INTERLOCK,
 		/// <summary>
 		﻿/// {{def(EventEnum:CHUCK_STATE)}}
@@ -92,6 +94,7 @@ namespace MtconnectCore.Standard.Contracts.Enums.Devices.DataItemTypes
 		﻿/// {{def(EventEnum:COMPOSITION_STATE)}}
 		/// </summary>
 		[MtconnectVersionApplicability(MtconnectVersions.V_1_4_0, "https://model.mtconnect.org/")]
+		[ObservationalSubType(typeof(CompositionStateSubTypes))]
 		COMPOSITION_STATE,
 		/// <summary>
 		﻿/// {{def(EventEnum:CONTROLLER_MODE)}}
@@ -102,6 +105,7 @@ namespace MtconnectCore.Standard.Contracts.Enums.Devices.DataItemTypes
 		﻿/// {{def(EventEnum:CONTROLLER_MODE_OVERRIDE)}}
 		/// </summary>
 		[MtconnectVersionApplicability(MtconnectVersions.V_1_4_0, "https://model.mtconnect.org/")]
+		[ObservationalSubType(typeof(ControllerModeOverrideSubTypes))]
 		CONTROLLER_MODE_OVERRIDE,
 		/// <summary>
 		﻿/// {{def(EventEnum:COUPLED_AXES)}}
@@ -112,6 +116,7 @@ namespace MtconnectCore.Standard.Contracts.Enums.Devices.DataItemTypes
 		﻿/// {{def(EventEnum:DATE_CODE)}}
 		/// </summary>
 		[MtconnectVersionApplicability(MtconnectVersions.V_1_5_0, "https://model.mtconnect.org/")]
+		[ObservationalSubType(typeof(DateCodeSubTypes))]
 		DATE_CODE,
 		/// <summary>
 		﻿/// {{def(EventEnum:DEVICE_UUID)}}
@@ -122,6 +127,7 @@ namespace MtconnectCore.Standard.Contracts.Enums.Devices.DataItemTypes
 		﻿/// {{def(EventEnum:DIRECTION)}}
 		/// </summary>
 		[MtconnectVersionApplicability(MtconnectVersions.V_1_0_1, "https://model.mtconnect.org/")]
+		[ObservationalSubType(typeof(DirectionSubTypes))]
 		DIRECTION,
 		/// <summary>
 		﻿/// {{def(EventEnum:DOOR_STATE)}}
@@ -137,11 +143,13 @@ namespace MtconnectCore.Standard.Contracts.Enums.Devices.DataItemTypes
 		﻿/// {{def(EventEnum:END_OF_BAR)}}
 		/// </summary>
 		[MtconnectVersionApplicability(MtconnectVersions.V_1_3_0, "https://model.mtconnect.org/")]
+		[ObservationalSubType(typeof(EndOfBarSubTypes))]
 		END_OF_BAR,
 		/// <summary>
 		﻿/// {{def(EventEnum:EQUIPMENT_MODE)}}
 		/// </summary>
 		[MtconnectVersionApplicability(MtconnectVersions.V_1_4_0, "https://model.mtconnect.org/")]
+		[ObservationalSubType(typeof(EquipmentModeSubTypes))]
 		EQUIPMENT_MODE,
 		/// <summary>
 		﻿/// {{def(EventEnum:EXECUTION)}}
@@ -157,12 +165,14 @@ namespace MtconnectCore.Standard.Contracts.Enums.Devices.DataItemTypes
 		﻿/// {{def(EventEnum:HARDNESS)}}
 		/// </summary>
 		[MtconnectVersionApplicability(MtconnectVersions.V_1_4_0, "https://model.mtconnect.org/")]
+		[ObservationalSubType(typeof(HardnessSubTypes))]
 		HARDNESS,
 		/// <summary>
 		﻿/// {{def(EventEnum:LINE)}}
 		/// </summary>
 		[Obsolete("Deprecated according to https://model.mtconnect.org/")]
 		[MtconnectVersionApplicability(MtconnectVersions.V_1_0_1, "https://model.mtconnect.org/", MtconnectVersions.V_1_4_0)]
+		[ObservationalSubType(typeof(LineSubTypes))]
 		LINE,
 		/// <summary>
 		﻿/// {{def(EventEnum:LINE_LABEL)}}
@@ -173,6 +183,7 @@ namespace MtconnectCore.Standard.Contracts.Enums.Devices.DataItemTypes
 		﻿/// {{def(EventEnum:LINE_NUMBER)}}
 		/// </summary>
 		[MtconnectVersionApplicability(MtconnectVersions.V_1_4_0, "https://model.mtconnect.org/")]
+		[ObservationalSubType(typeof(LineNumberSubTypes))]
 		LINE_NUMBER,
 		/// <summary>
 		﻿/// {{def(EventEnum:MATERIAL)}}
@@ -183,6 +194,7 @@ namespace MtconnectCore.Standard.Contracts.Enums.Devices.DataItemTypes
 		﻿/// {{def(EventEnum:MATERIAL_LAYER)}}
 		/// </summary>
 		[MtconnectVersionApplicability(MtconnectVersions.V_1_5_0, "https://model.mtconnect.org/")]
+		[ObservationalSubType(typeof(MaterialLayerSubTypes))]
 		MATERIAL_LAYER,
 		/// <summary>
 		﻿/// {{def(EventEnum:MESSAGE)}}
@@ -203,6 +215,7 @@ namespace MtconnectCore.Standard.Contracts.Enums.Devices.DataItemTypes
 		﻿/// {{def(EventEnum:PART_COUNT)}}
 		/// </summary>
 		[MtconnectVersionApplicability(MtconnectVersions.V_1_0_1, "https://model.mtconnect.org/")]
+		[ObservationalSubType(typeof(PartCountSubTypes))]
 		PART_COUNT,
 		/// <summary>
 		﻿/// {{def(EventEnum:PART_DETECT)}}
@@ -224,6 +237,7 @@ namespace MtconnectCore.Standard.Contracts.Enums.Devices.DataItemTypes
 		﻿/// {{def(EventEnum:PATH_FEEDRATE_OVERRIDE)}}
 		/// </summary>
 		[MtconnectVersionApplicability(MtconnectVersions.V_1_3_0, "https://model.mtconnect.org/")]
+		[ObservationalSubType(typeof(PathFeedrateOverrideSubTypes))]
 		PATH_FEEDRATE_OVERRIDE,
 		/// <summary>
 		﻿/// {{def(EventEnum:PATH_MODE)}}
@@ -234,6 +248,7 @@ namespace MtconnectCore.Standard.Contracts.Enums.Devices.DataItemTypes
 		﻿/// {{def(EventEnum:POWER_STATE)}}
 		/// </summary>
 		[MtconnectVersionApplicability(MtconnectVersions.V_1_1_0, "https://model.mtconnect.org/")]
+		[ObservationalSubType(typeof(PowerStateSubTypes))]
 		POWER_STATE,
 		/// <summary>
 		﻿/// {{def(EventEnum:POWER_STATUS)}}
@@ -245,16 +260,19 @@ namespace MtconnectCore.Standard.Contracts.Enums.Devices.DataItemTypes
 		﻿/// {{def(EventEnum:PROCESS_TIME)}}
 		/// </summary>
 		[MtconnectVersionApplicability(MtconnectVersions.V_1_5_0, "https://model.mtconnect.org/")]
+		[ObservationalSubType(typeof(ProcessTimeSubTypes))]
 		PROCESS_TIME,
 		/// <summary>
 		﻿/// {{def(EventEnum:PROGRAM)}}
 		/// </summary>
 		[MtconnectVersionApplicability(MtconnectVersions.V_1_0_1, "https://model.mtconnect.org/")]
+		[ObservationalSubType(typeof(ProgramSubTypes))]
 		PROGRAM,
 		/// <summary>
 		﻿/// {{def(EventEnum:PROGRAM_COMMENT)}}
 		/// </summary>
 		[MtconnectVersionApplicability(MtconnectVersions.V_1_3_0, "https://model.mtconnect.org/")]
+		[ObservationalSubType(typeof(ProgramCommentSubTypes))]
 		PROGRAM_COMMENT,
 		/// <summary>
 		﻿/// {{def(EventEnum:PROGRAM_EDIT)}}
@@ -270,16 +288,19 @@ namespace MtconnectCore.Standard.Contracts.Enums.Devices.DataItemTypes
 		﻿/// {{def(EventEnum:PROGRAM_HEADER)}}
 		/// </summary>
 		[MtconnectVersionApplicability(MtconnectVersions.V_1_3_0, "https://model.mtconnect.org/")]
+		[ObservationalSubType(typeof(ProgramHeaderSubTypes))]
 		PROGRAM_HEADER,
 		/// <summary>
 		﻿/// {{def(EventEnum:PROGRAM_LOCATION)}}
 		/// </summary>
 		[MtconnectVersionApplicability(MtconnectVersions.V_1_5_0, "https://model.mtconnect.org/")]
+		[ObservationalSubType(typeof(ProgramLocationSubTypes))]
 		PROGRAM_LOCATION,
 		/// <summary>
 		﻿/// {{def(EventEnum:PROGRAM_LOCATION_TYPE)}}
 		/// </summary>
 		[MtconnectVersionApplicability(MtconnectVersions.V_1_5_0, "https://model.mtconnect.org/")]
+		[ObservationalSubType(typeof(ProgramLocationTypeSubTypes))]
 		PROGRAM_LOCATION_TYPE,
 		/// <summary>
 		﻿/// {{def(EventEnum:PROGRAM_NEST_LEVEL)}}  If an initial value is not defined, the nesting level associated with the highest or initial nesting level of the program <b>MUST</b> default to zero (0). 
@@ -331,11 +352,13 @@ namespace MtconnectCore.Standard.Contracts.Enums.Devices.DataItemTypes
 		﻿/// {{def(EventEnum:TOOL_OFFSET)}}
 		/// </summary>
 		[MtconnectVersionApplicability(MtconnectVersions.V_1_4_0, "https://model.mtconnect.org/")]
+		[ObservationalSubType(typeof(ToolOffsetSubTypes))]
 		TOOL_OFFSET,
 		/// <summary>
 		﻿/// {{def(EventEnum:USER)}}
 		/// </summary>
 		[MtconnectVersionApplicability(MtconnectVersions.V_1_4_0, "https://model.mtconnect.org/")]
+		[ObservationalSubType(typeof(UserSubTypes))]
 		USER,
 		/// <summary>
 		﻿/// {{def(EventEnum:VARIABLE)}}
@@ -366,31 +389,37 @@ namespace MtconnectCore.Standard.Contracts.Enums.Devices.DataItemTypes
 		﻿/// {{def(EventEnum:OPERATING_SYSTEM)}}
 		/// </summary>
 		[MtconnectVersionApplicability(MtconnectVersions.V_1_6_0, "https://model.mtconnect.org/")]
+		[ObservationalSubType(typeof(OperatingSystemSubTypes))]
 		OPERATING_SYSTEM,
 		/// <summary>
 		﻿/// {{def(EventEnum:FIRMWARE)}}
 		/// </summary>
 		[MtconnectVersionApplicability(MtconnectVersions.V_1_6_0, "https://model.mtconnect.org/")]
+		[ObservationalSubType(typeof(FirmwareSubTypes))]
 		FIRMWARE,
 		/// <summary>
 		﻿/// {{def(EventEnum:APPLICATION)}}
 		/// </summary>
 		[MtconnectVersionApplicability(MtconnectVersions.V_1_6_0, "https://model.mtconnect.org/")]
+		[ObservationalSubType(typeof(ApplicationSubTypes))]
 		APPLICATION,
 		/// <summary>
 		﻿/// {{def(EventEnum:LIBRARY)}}
 		/// </summary>
 		[MtconnectVersionApplicability(MtconnectVersions.V_1_6_0, "https://model.mtconnect.org/")]
+		[ObservationalSubType(typeof(LibrarySubTypes))]
 		LIBRARY,
 		/// <summary>
 		﻿/// {{def(EventEnum:HARDWARE)}}
 		/// </summary>
 		[MtconnectVersionApplicability(MtconnectVersions.V_1_4_0, "https://model.mtconnect.org/")]
+		[ObservationalSubType(typeof(HardwareSubTypes))]
 		HARDWARE,
 		/// <summary>
 		﻿/// {{def(EventEnum:NETWORK)}}
 		/// </summary>
 		[MtconnectVersionApplicability(MtconnectVersions.V_1_6_0, "https://model.mtconnect.org/")]
+		[ObservationalSubType(typeof(NetworkSubTypes))]
 		NETWORK,
 		/// <summary>
 		﻿/// {{def(EventEnum:ROTATION)}}
@@ -406,6 +435,7 @@ namespace MtconnectCore.Standard.Contracts.Enums.Devices.DataItemTypes
 		﻿/// {{def(EventEnum:PROCESS_KIND_ID)}}
 		/// </summary>
 		[MtconnectVersionApplicability(MtconnectVersions.V_1_7_0, "https://model.mtconnect.org/")]
+		[ObservationalSubType(typeof(ProcessKindIdSubTypes))]
 		PROCESS_KIND_ID,
 		/// <summary>
 		﻿/// {{def(EventEnum:PART_STATUS)}}  If unique identifier is given, part status is for that individual. If group identifier is given without a unique identifier, then the status is assumed to be for the whole group.
@@ -421,11 +451,13 @@ namespace MtconnectCore.Standard.Contracts.Enums.Devices.DataItemTypes
 		﻿/// {{def(EventEnum:PROCESS_AGGREGATE_ID)}}
 		/// </summary>
 		[MtconnectVersionApplicability(MtconnectVersions.V_1_7_0, "https://model.mtconnect.org/")]
+		[ObservationalSubType(typeof(ProcessAggregateIdSubTypes))]
 		PROCESS_AGGREGATE_ID,
 		/// <summary>
 		﻿/// {{def(EventEnum:PART_KIND_ID)}}  If no {{property(subType)}} is specified, <c>UUID</c> is default. 
 		/// </summary>
 		[MtconnectVersionApplicability(MtconnectVersions.V_1_7_0, "https://model.mtconnect.org/")]
+		[ObservationalSubType(typeof(PartKindIdSubTypes))]
 		PART_KIND_ID,
 		/// <summary>
 		﻿/// {{def(EventEnum:ADAPTER_URI)}}
@@ -481,36 +513,43 @@ namespace MtconnectCore.Standard.Contracts.Enums.Devices.DataItemTypes
 		﻿/// {{def(EventEnum:PROCESS_OCCURRENCE_ID)}}
 		/// </summary>
 		[MtconnectVersionApplicability(MtconnectVersions.V_1_7_0, "https://model.mtconnect.org/")]
+		[ObservationalSubType(typeof(ProcessOccurrenceIdSubTypes))]
 		PROCESS_OCCURRENCE_ID,
 		/// <summary>
 		﻿/// {{def(EventEnum:PART_GROUP_ID)}}  If no {{property(subType)}} is specified, <c>UUID</c> is default.
 		/// </summary>
 		[MtconnectVersionApplicability(MtconnectVersions.V_1_7_0, "https://model.mtconnect.org/")]
+		[ObservationalSubType(typeof(PartGroupIdSubTypes))]
 		PART_GROUP_ID,
 		/// <summary>
 		﻿/// {{def(EventEnum:PART_UNIQUE_ID)}}  If no {{property(subType)}} is specified, <c>UUID</c> is default. 
 		/// </summary>
 		[MtconnectVersionApplicability(MtconnectVersions.V_1_7_0, "https://model.mtconnect.org/")]
+		[ObservationalSubType(typeof(PartUniqueIdSubTypes))]
 		PART_UNIQUE_ID,
 		/// <summary>
 		﻿/// {{def(EventEnum:ACTIVATION_COUNT)}}
 		/// </summary>
 		[MtconnectVersionApplicability(MtconnectVersions.V_1_8_0, "https://model.mtconnect.org/")]
+		[ObservationalSubType(typeof(ActivationCountSubTypes))]
 		ACTIVATION_COUNT,
 		/// <summary>
 		﻿/// {{def(EventEnum:DEACTIVATION_COUNT)}}
 		/// </summary>
 		[MtconnectVersionApplicability(MtconnectVersions.V_1_8_0, "https://model.mtconnect.org/")]
+		[ObservationalSubType(typeof(DeactivationCountSubTypes))]
 		DEACTIVATION_COUNT,
 		/// <summary>
 		﻿/// {{def(EventEnum:TRANSFER_COUNT)}}
 		/// </summary>
 		[MtconnectVersionApplicability(MtconnectVersions.V_1_8_0, "https://model.mtconnect.org/")]
+		[ObservationalSubType(typeof(TransferCountSubTypes))]
 		TRANSFER_COUNT,
 		/// <summary>
 		﻿/// {{def(EventEnum:LOAD_COUNT)}}
 		/// </summary>
 		[MtconnectVersionApplicability(MtconnectVersions.V_1_8_0, "https://model.mtconnect.org/")]
+		[ObservationalSubType(typeof(LoadCountSubTypes))]
 		LOAD_COUNT,
 		/// <summary>
 		﻿/// {{def(EventEnum:PART_PROCESSING_STATE)}}
@@ -526,6 +565,7 @@ namespace MtconnectCore.Standard.Contracts.Enums.Devices.DataItemTypes
 		﻿/// {{def(EventEnum:VALVE_STATE)}}
 		/// </summary>
 		[MtconnectVersionApplicability(MtconnectVersions.V_1_8_0, "https://model.mtconnect.org/")]
+		[ObservationalSubType(typeof(ValveStateSubTypes))]
 		VALVE_STATE,
 		/// <summary>
 		﻿/// {{def(EventEnum:LOCK_STATE)}}
@@ -536,11 +576,13 @@ namespace MtconnectCore.Standard.Contracts.Enums.Devices.DataItemTypes
 		﻿/// {{def(EventEnum:UNLOAD_COUNT)}}
 		/// </summary>
 		[MtconnectVersionApplicability(MtconnectVersions.V_1_8_0, "https://model.mtconnect.org/")]
+		[ObservationalSubType(typeof(UnloadCountSubTypes))]
 		UNLOAD_COUNT,
 		/// <summary>
 		﻿/// {{def(EventEnum:CYCLE_COUNT)}}
 		/// </summary>
 		[MtconnectVersionApplicability(MtconnectVersions.V_1_8_0, "https://model.mtconnect.org/")]
+		[ObservationalSubType(typeof(CycleCountSubTypes))]
 		CYCLE_COUNT,
 		/// <summary>
 		﻿/// {{def(EventEnum:OPERATING_MODE)}}

--- a/MtconnectCore/Standard/Contracts/Enums/Devices/DataItemTypes/SampleTypes.cs
+++ b/MtconnectCore/Standard/Contracts/Enums/Devices/DataItemTypes/SampleTypes.cs
@@ -15,7 +15,7 @@ namespace MtconnectCore.Standard.Contracts.Enums.Devices.DataItemTypes
 		﻿/// {{def(SampleEnum:ACCELERATION)}}
 		/// </summary>
 		[MtconnectVersionApplicability(MtconnectVersions.V_1_0_1, "https://model.mtconnect.org/")]
-        [ObservationalSubType(typeof(AccelerationSubTypes))]
+		[ObservationalSubType(typeof(AccelerationSubTypes))]
 		ACCELERATION,
 		/// <summary>
 		﻿/// {{def(SampleEnum:ACCUMULATED_TIME)}}
@@ -27,16 +27,19 @@ namespace MtconnectCore.Standard.Contracts.Enums.Devices.DataItemTypes
 		/// </summary>
 		[Obsolete("Deprecated according to https://model.mtconnect.org/")]
 		[MtconnectVersionApplicability(MtconnectVersions.V_1_0_1, "https://model.mtconnect.org/", MtconnectVersions.V_1_6_0)]
+		[ObservationalSubType(typeof(AmperageSubTypes))]
 		AMPERAGE,
 		/// <summary>
 		﻿/// {{def(SampleEnum:ANGLE)}}
 		/// </summary>
 		[MtconnectVersionApplicability(MtconnectVersions.V_1_0_1, "https://model.mtconnect.org/")]
+		[ObservationalSubType(typeof(AngleSubTypes))]
 		ANGLE,
 		/// <summary>
 		﻿/// {{def(SampleEnum:ANGULAR_ACCELERATION)}}
 		/// </summary>
 		[MtconnectVersionApplicability(MtconnectVersions.V_1_0_1, "https://model.mtconnect.org/")]
+		[ObservationalSubType(typeof(AngularAccelerationSubTypes))]
 		ANGULAR_ACCELERATION,
 		/// <summary>
 		﻿/// {{def(SampleEnum:ANGULAR_VELOCITY)}}
@@ -47,6 +50,7 @@ namespace MtconnectCore.Standard.Contracts.Enums.Devices.DataItemTypes
 		﻿/// {{def(SampleEnum:AXIS_FEEDRATE)}}
 		/// </summary>
 		[MtconnectVersionApplicability(MtconnectVersions.V_1_0_1, "https://model.mtconnect.org/")]
+		[ObservationalSubType(typeof(AxisFeedrateSubTypes))]
 		AXIS_FEEDRATE,
 		/// <summary>
 		﻿/// {{def(SampleEnum:CAPACITY_FLUID)}}
@@ -72,6 +76,7 @@ namespace MtconnectCore.Standard.Contracts.Enums.Devices.DataItemTypes
 		﻿/// {{def(SampleEnum:CUTTING_SPEED)}}
 		/// </summary>
 		[MtconnectVersionApplicability(MtconnectVersions.V_1_5_0, "https://model.mtconnect.org/")]
+		[ObservationalSubType(typeof(CuttingSpeedSubTypes))]
 		CUTTING_SPEED,
 		/// <summary>
 		﻿/// {{def(SampleEnum:DENSITY)}}
@@ -82,26 +87,31 @@ namespace MtconnectCore.Standard.Contracts.Enums.Devices.DataItemTypes
 		﻿/// {{def(SampleEnum:DEPOSITION_ACCELERATION_VOLUMETRIC)}}
 		/// </summary>
 		[MtconnectVersionApplicability(MtconnectVersions.V_1_5_0, "https://model.mtconnect.org/")]
+		[ObservationalSubType(typeof(DepositionAccelerationVolumetricSubTypes))]
 		DEPOSITION_ACCELERATION_VOLUMETRIC,
 		/// <summary>
 		﻿/// {{def(SampleEnum:DEPOSITION_DENSITY)}}
 		/// </summary>
 		[MtconnectVersionApplicability(MtconnectVersions.V_1_5_0, "https://model.mtconnect.org/")]
+		[ObservationalSubType(typeof(DepositionDensitySubTypes))]
 		DEPOSITION_DENSITY,
 		/// <summary>
 		﻿/// {{def(SampleEnum:DEPOSITION_MASS)}}
 		/// </summary>
 		[MtconnectVersionApplicability(MtconnectVersions.V_1_5_0, "https://model.mtconnect.org/")]
+		[ObservationalSubType(typeof(DepositionMassSubTypes))]
 		DEPOSITION_MASS,
 		/// <summary>
 		﻿/// {{def(SampleEnum:DEPOSITION_RATE_VOLUMETRIC)}}
 		/// </summary>
 		[MtconnectVersionApplicability(MtconnectVersions.V_1_5_0, "https://model.mtconnect.org/")]
+		[ObservationalSubType(typeof(DepositionRateVolumetricSubTypes))]
 		DEPOSITION_RATE_VOLUMETRIC,
 		/// <summary>
 		﻿/// {{def(SampleEnum:DEPOSITION_VOLUME)}}
 		/// </summary>
 		[MtconnectVersionApplicability(MtconnectVersions.V_1_5_0, "https://model.mtconnect.org/")]
+		[ObservationalSubType(typeof(DepositionVolumeSubTypes))]
 		DEPOSITION_VOLUME,
 		/// <summary>
 		﻿/// {{def(SampleEnum:DISPLACEMENT)}}
@@ -117,6 +127,7 @@ namespace MtconnectCore.Standard.Contracts.Enums.Devices.DataItemTypes
 		﻿/// {{def(SampleEnum:EQUIPMENT_TIMER)}}
 		/// </summary>
 		[MtconnectVersionApplicability(MtconnectVersions.V_1_4_0, "https://model.mtconnect.org/")]
+		[ObservationalSubType(typeof(EquipmentTimerSubTypes))]
 		EQUIPMENT_TIMER,
 		/// <summary>
 		﻿/// {{def(SampleEnum:FILL_LEVEL)}}
@@ -138,11 +149,13 @@ namespace MtconnectCore.Standard.Contracts.Enums.Devices.DataItemTypes
 		/// </summary>
 		[Obsolete("Deprecated according to https://model.mtconnect.org/")]
 		[MtconnectVersionApplicability(MtconnectVersions.V_1_0_1, "https://model.mtconnect.org/", MtconnectVersions.V_1_1_0)]
+		[ObservationalSubType(typeof(GlobalPositionSubTypes))]
 		GLOBAL_POSITION,
 		/// <summary>
 		﻿/// {{def(SampleEnum:LENGTH)}}
 		/// </summary>
 		[MtconnectVersionApplicability(MtconnectVersions.V_1_3_0, "https://model.mtconnect.org/")]
+		[ObservationalSubType(typeof(LengthSubTypes))]
 		LENGTH,
 		/// <summary>
 		﻿/// {{def(SampleEnum:LEVEL)}}
@@ -169,16 +182,19 @@ namespace MtconnectCore.Standard.Contracts.Enums.Devices.DataItemTypes
 		﻿/// {{def(SampleEnum:PATH_FEEDRATE)}}
 		/// </summary>
 		[MtconnectVersionApplicability(MtconnectVersions.V_1_0_1, "https://model.mtconnect.org/")]
+		[ObservationalSubType(typeof(PathFeedrateSubTypes))]
 		PATH_FEEDRATE,
 		/// <summary>
 		﻿/// {{def(SampleEnum:PATH_FEEDRATE_PER_REVOLUTION)}}
 		/// </summary>
 		[MtconnectVersionApplicability(MtconnectVersions.V_1_5_0, "https://model.mtconnect.org/")]
+		[ObservationalSubType(typeof(PathFeedratePerRevolutionSubTypes))]
 		PATH_FEEDRATE_PER_REVOLUTION,
 		/// <summary>
 		﻿/// {{def(SampleEnum:PATH_POSITION)}}
 		/// </summary>
 		[MtconnectVersionApplicability(MtconnectVersions.V_1_1_0, "https://model.mtconnect.org/")]
+		[ObservationalSubType(typeof(PathPositionSubTypes))]
 		PATH_POSITION,
 		/// <summary>
 		﻿/// {{def(SampleEnum:PH)}}
@@ -189,6 +205,7 @@ namespace MtconnectCore.Standard.Contracts.Enums.Devices.DataItemTypes
 		﻿/// {{def(SampleEnum:POSITION)}}
 		/// </summary>
 		[MtconnectVersionApplicability(MtconnectVersions.V_1_0_1, "https://model.mtconnect.org/")]
+		[ObservationalSubType(typeof(PositionSubTypes))]
 		POSITION,
 		/// <summary>
 		﻿/// {{def(SampleEnum:POWER_FACTOR)}}
@@ -204,6 +221,7 @@ namespace MtconnectCore.Standard.Contracts.Enums.Devices.DataItemTypes
 		﻿/// {{def(SampleEnum:PROCESS_TIMER)}}
 		/// </summary>
 		[MtconnectVersionApplicability(MtconnectVersions.V_1_4_0, "https://model.mtconnect.org/")]
+		[ObservationalSubType(typeof(ProcessTimerSubTypes))]
 		PROCESS_TIMER,
 		/// <summary>
 		﻿/// {{def(SampleEnum:RESISTANCE)}}
@@ -214,17 +232,20 @@ namespace MtconnectCore.Standard.Contracts.Enums.Devices.DataItemTypes
 		﻿/// {{def(SampleEnum:ROTARY_VELOCITY)}}
 		/// </summary>
 		[MtconnectVersionApplicability(MtconnectVersions.V_1_2_0, "https://model.mtconnect.org/")]
+		[ObservationalSubType(typeof(RotaryVelocitySubTypes))]
 		ROTARY_VELOCITY,
 		/// <summary>
 		﻿/// {{def(SampleEnum:SOUND_LEVEL)}}
 		/// </summary>
 		[MtconnectVersionApplicability(MtconnectVersions.V_1_2_0, "https://model.mtconnect.org/")]
+		[ObservationalSubType(typeof(SoundLevelSubTypes))]
 		SOUND_LEVEL,
 		/// <summary>
 		﻿/// {{def(SampleEnum:SPINDLE_SPEED)}}
 		/// </summary>
 		[Obsolete("Deprecated according to https://model.mtconnect.org/")]
 		[MtconnectVersionApplicability(MtconnectVersions.V_1_0_1, "https://model.mtconnect.org/", MtconnectVersions.V_1_2_0)]
+		[ObservationalSubType(typeof(SpindleSpeedSubTypes))]
 		SPINDLE_SPEED,
 		/// <summary>
 		﻿/// {{def(SampleEnum:STRAIN)}}
@@ -266,6 +287,7 @@ namespace MtconnectCore.Standard.Contracts.Enums.Devices.DataItemTypes
 		/// </summary>
 		[Obsolete("Deprecated according to https://model.mtconnect.org/")]
 		[MtconnectVersionApplicability(MtconnectVersions.V_1_0_1, "https://model.mtconnect.org/", MtconnectVersions.V_1_6_0)]
+		[ObservationalSubType(typeof(VoltageSubTypes))]
 		VOLTAGE,
 		/// <summary>
 		﻿/// {{def(SampleEnum:VOLT_AMPERE)}}
@@ -281,36 +303,43 @@ namespace MtconnectCore.Standard.Contracts.Enums.Devices.DataItemTypes
 		﻿/// {{def(SampleEnum:VOLUME_FLUID)}}
 		/// </summary>
 		[MtconnectVersionApplicability(MtconnectVersions.V_1_5_0, "https://model.mtconnect.org/")]
+		[ObservationalSubType(typeof(VolumeFluidSubTypes))]
 		VOLUME_FLUID,
 		/// <summary>
 		﻿/// {{def(SampleEnum:VOLUME_SPATIAL)}}
 		/// </summary>
 		[MtconnectVersionApplicability(MtconnectVersions.V_1_5_0, "https://model.mtconnect.org/")]
+		[ObservationalSubType(typeof(VolumeSpatialSubTypes))]
 		VOLUME_SPATIAL,
 		/// <summary>
 		﻿/// {{def(SampleEnum:WATTAGE)}}
 		/// </summary>
 		[MtconnectVersionApplicability(MtconnectVersions.V_1_0_1, "https://model.mtconnect.org/")]
+		[ObservationalSubType(typeof(WattageSubTypes))]
 		WATTAGE,
 		/// <summary>
 		﻿/// {{def(SampleEnum:AMPERAGE_DC)}}
 		/// </summary>
 		[MtconnectVersionApplicability(MtconnectVersions.V_1_6_0, "https://model.mtconnect.org/")]
+		[ObservationalSubType(typeof(AmperageDCSubTypes))]
 		AMPERAGE_D_C,
 		/// <summary>
 		﻿/// {{def(SampleEnum:AMPERAGE_AC)}}
 		/// </summary>
 		[MtconnectVersionApplicability(MtconnectVersions.V_1_6_0, "https://model.mtconnect.org/")]
+		[ObservationalSubType(typeof(AmperageACSubTypes))]
 		AMPERAGE_A_C,
 		/// <summary>
 		﻿/// {{def(SampleEnum:VOLTAGE_AC)}}
 		/// </summary>
 		[MtconnectVersionApplicability(MtconnectVersions.V_1_6_0, "https://model.mtconnect.org/")]
+		[ObservationalSubType(typeof(VoltageACSubTypes))]
 		VOLTAGE_A_C,
 		/// <summary>
 		﻿/// {{def(SampleEnum:VOLTAGE_DC)}}
 		/// </summary>
 		[MtconnectVersionApplicability(MtconnectVersions.V_1_6_0, "https://model.mtconnect.org/")]
+		[ObservationalSubType(typeof(VoltageDCSubTypes))]
 		VOLTAGE_D_C,
 		/// <summary>
 		﻿/// {{def(SampleEnum:X_DIMENSION)}}
@@ -336,31 +365,37 @@ namespace MtconnectCore.Standard.Contracts.Enums.Devices.DataItemTypes
 		﻿/// {{def(SampleEnum:ORIENTATION)}}
 		/// </summary>
 		[MtconnectVersionApplicability(MtconnectVersions.V_1_6_0, "https://model.mtconnect.org/")]
+		[ObservationalSubType(typeof(OrientationSubTypes))]
 		ORIENTATION,
 		/// <summary>
 		﻿/// {{def(SampleEnum:HUMIDITY_RELATIVE)}}
 		/// </summary>
 		[MtconnectVersionApplicability(MtconnectVersions.V_1_6_0, "https://model.mtconnect.org/")]
+		[ObservationalSubType(typeof(HumidityRelativeSubTypes))]
 		HUMIDITY_RELATIVE,
 		/// <summary>
 		﻿/// {{def(SampleEnum:HUMIDITY_ABSOLUTE)}}
 		/// </summary>
 		[MtconnectVersionApplicability(MtconnectVersions.V_1_6_0, "https://model.mtconnect.org/")]
+		[ObservationalSubType(typeof(HumidityAbsoluteSubTypes))]
 		HUMIDITY_ABSOLUTE,
 		/// <summary>
 		﻿/// {{def(SampleEnum:HUMIDITY_SPECIFIC)}}
 		/// </summary>
 		[MtconnectVersionApplicability(MtconnectVersions.V_1_6_0, "https://model.mtconnect.org/")]
+		[ObservationalSubType(typeof(HumiditySpecificSubTypes))]
 		HUMIDITY_SPECIFIC,
 		/// <summary>
 		﻿/// {{def(SampleEnum:PRESSURIZATION_RATE)}}
 		/// </summary>
 		[MtconnectVersionApplicability(MtconnectVersions.V_1_7_0, "https://model.mtconnect.org/")]
+		[ObservationalSubType(typeof(PressurizationRateSubTypes))]
 		PRESSURIZATION_RATE,
 		/// <summary>
 		﻿/// {{def(SampleEnum:DECELERATION)}}
 		/// </summary>
 		[MtconnectVersionApplicability(MtconnectVersions.V_1_7_0, "https://model.mtconnect.org/")]
+		[ObservationalSubType(typeof(DecelerationSubTypes))]
 		DECELERATION,
 		/// <summary>
 		﻿/// {{def(SampleEnum:ASSET_UPDATE_RATE)}}
@@ -371,6 +406,7 @@ namespace MtconnectCore.Standard.Contracts.Enums.Devices.DataItemTypes
 		﻿/// {{def(SampleEnum:ANGULAR_DECELERATION)}}
 		/// </summary>
 		[MtconnectVersionApplicability(MtconnectVersions.V_1_7_0, "https://model.mtconnect.org/")]
+		[ObservationalSubType(typeof(AngularDecelerationSubTypes))]
 		ANGULAR_DECELERATION,
 		/// <summary>
 		﻿/// {{def(SampleEnum:OBSERVATION_UPDATE_RATE)}}
@@ -406,51 +442,61 @@ namespace MtconnectCore.Standard.Contracts.Enums.Devices.DataItemTypes
 		﻿/// {{def(SampleEnum:BATTERY_CAPACITY)}}
 		/// </summary>
 		[MtconnectVersionApplicability(MtconnectVersions.V_2_1_0, "https://model.mtconnect.org/")]
+		[ObservationalSubType(typeof(BatteryCapacitySubTypes))]
 		BATTERY_CAPACITY,
 		/// <summary>
 		﻿/// {{def(SampleEnum:DISCHARGE_RATE)}}
 		/// </summary>
 		[MtconnectVersionApplicability(MtconnectVersions.V_2_1_0, "https://model.mtconnect.org/")]
+		[ObservationalSubType(typeof(DischargeRateSubTypes))]
 		DISCHARGE_RATE,
 		/// <summary>
 		﻿/// {{def(SampleEnum:CHARGE_RATE)}}
 		/// </summary>
 		[MtconnectVersionApplicability(MtconnectVersions.V_2_1_0, "https://model.mtconnect.org/")]
+		[ObservationalSubType(typeof(ChargeRateSubTypes))]
 		CHARGE_RATE,
 		/// <summary>
 		﻿/// {{def(SampleEnum:BATTERY_CHARGE)}}
 		/// </summary>
 		[MtconnectVersionApplicability(MtconnectVersions.V_2_1_0, "https://model.mtconnect.org/")]
+		[ObservationalSubType(typeof(BatteryChargeSubTypes))]
 		BATTERY_CHARGE,
 		/// <summary>
 		﻿/// {{def(SampleEnum:SETTLING_ERROR)}}
 		/// </summary>
 		[MtconnectVersionApplicability(MtconnectVersions.V_2_1_0, "https://model.mtconnect.org/")]
+		[ObservationalSubType(typeof(SettlingErrorSubTypes))]
 		SETTLING_ERROR,
 		/// <summary>
 		﻿/// {{def(SampleEnum:SETTLING_ERROR_LINEAR)}}
 		/// </summary>
 		[MtconnectVersionApplicability(MtconnectVersions.V_2_1_0, "https://model.mtconnect.org/")]
+		[ObservationalSubType(typeof(SettlingErrorLinearSubTypes))]
 		SETTLING_ERROR_LINEAR,
 		/// <summary>
 		﻿/// {{def(SampleEnum:SETTLING_ERROR_ANGULAR)}}
 		/// </summary>
 		[MtconnectVersionApplicability(MtconnectVersions.V_2_1_0, "https://model.mtconnect.org/")]
+		[ObservationalSubType(typeof(SettlingErrorAngularSubTypes))]
 		SETTLING_ERROR_ANGULAR,
 		/// <summary>
 		﻿/// {{def(SampleEnum:FOLLOWING_ERROR)}}
 		/// </summary>
 		[MtconnectVersionApplicability(MtconnectVersions.V_2_1_0, "https://model.mtconnect.org/")]
+		[ObservationalSubType(typeof(FollowingErrorSubTypes))]
 		FOLLOWING_ERROR,
 		/// <summary>
 		﻿/// {{def(SampleEnum:FOLLOWING_ERROR_ANGULAR)}}
 		/// </summary>
 		[MtconnectVersionApplicability(MtconnectVersions.V_2_1_0, "https://model.mtconnect.org/")]
+		[ObservationalSubType(typeof(FollowingErrorAngularSubTypes))]
 		FOLLOWING_ERROR_ANGULAR,
 		/// <summary>
 		﻿/// {{def(SampleEnum:FOLLOWING_ERROR_LINEAR)}}
 		/// </summary>
 		[MtconnectVersionApplicability(MtconnectVersions.V_2_1_0, "https://model.mtconnect.org/")]
+		[ObservationalSubType(typeof(FollowingErrorLinearSubTypes))]
 		FOLLOWING_ERROR_LINEAR,
 		/// <summary>
 		﻿/// {{def(SampleEnum:DISPLACEMENT_LINEAR)}}  > Note: The displacement vector <b>MAY</b> be defined by the motion of the owning <see cref="component">component</see>.

--- a/MtconnectCore/Standard/Contracts/Enums/Devices/DataItemTypes/SampleTypes.cs
+++ b/MtconnectCore/Standard/Contracts/Enums/Devices/DataItemTypes/SampleTypes.cs
@@ -15,6 +15,7 @@ namespace MtconnectCore.Standard.Contracts.Enums.Devices.DataItemTypes
 		﻿/// {{def(SampleEnum:ACCELERATION)}}
 		/// </summary>
 		[MtconnectVersionApplicability(MtconnectVersions.V_1_0_1, "https://model.mtconnect.org/")]
+        [ObservationalSubType(typeof(AccelerationSubTypes))]
 		ACCELERATION,
 		/// <summary>
 		﻿/// {{def(SampleEnum:ACCUMULATED_TIME)}}

--- a/MtconnectTranspiler.Sinks.MtconnectCore/Models/MtconnectCoreEnum.cs
+++ b/MtconnectTranspiler.Sinks.MtconnectCore/Models/MtconnectCoreEnum.cs
@@ -8,6 +8,9 @@ namespace MtconnectTranspiler.Sinks.MtconnectCore.Models
     [ScribanTemplate("MtconnectCore.Enum.scriban")]
     public class MtconnectCoreEnum : CSharp.Models.Enum
     {
+        // NOTE: Only used for CATEGORY types that have subTypes.
+        public Dictionary<string, string> SubTypes { get; set; } = new Dictionary<string, string>();
+
         public MtconnectCoreEnum(MTConnectModel model, XmiElement source, string name) : base(model, source, name) { }
 
         public MtconnectCoreEnum(MTConnectModel model, UmlEnumeration source) : base(model, source) { }

--- a/MtconnectTranspiler.Sinks.MtconnectCore/Templates/MtconnectCore.Enum.scriban
+++ b/MtconnectTranspiler.Sinks.MtconnectCore/Templates/MtconnectCore.Enum.scriban
@@ -23,7 +23,9 @@ namespace {{ to_pascal_code source.namespace }}
 		[Obsolete("Deprecated according to https://model.mtconnect.org/")]
 		{{~ end ~}}
 		{{ include 'MtconnectVersionApplicability.scriban' item }}
-		{{ include 'ObservationalSubType.scriban' source item }}
+		{{~ if category_contains source item ~}}
+		[ObservationalSubType(typeof({{ source?.sub_types[item.name] }}))]
+{{ end ~}}
 		{{ item.name }},
 	{{~ end ~}}
 	}

--- a/MtconnectTranspiler.Sinks.MtconnectCore/Templates/MtconnectCore.Enum.scriban
+++ b/MtconnectTranspiler.Sinks.MtconnectCore/Templates/MtconnectCore.Enum.scriban
@@ -23,6 +23,7 @@ namespace {{ to_pascal_code source.namespace }}
 		[Obsolete("Deprecated according to https://model.mtconnect.org/")]
 		{{~ end ~}}
 		{{ include 'MtconnectVersionApplicability.scriban' item }}
+		{{ include 'ObservationalSubType.scriban' source item }}
 		{{ item.name }},
 	{{~ end ~}}
 	}

--- a/MtconnectTranspiler.Sinks.MtconnectCore/Templates/ObservationalSubType.scriban
+++ b/MtconnectTranspiler.Sinks.MtconnectCore/Templates/ObservationalSubType.scriban
@@ -1,0 +1,3 @@
+﻿{{~
+subType=$1?.sub_types[$2.name] ~}}
+{{~ if subType && subType != "" ~}}[ObservationalSubType(typeof({{ subType }}))]{{~ end ~}}

--- a/MtconnectTranspiler.Sinks.MtconnectCore/Templates/ObservationalSubType.scriban
+++ b/MtconnectTranspiler.Sinks.MtconnectCore/Templates/ObservationalSubType.scriban
@@ -1,3 +1,0 @@
-﻿{{~
-subType=$1?.sub_types[$2.name] ~}}
-{{~ if subType && subType != "" ~}}[ObservationalSubType(typeof({{ subType }}))]{{~ end ~}}

--- a/MtconnectTranspiler.Sinks.MtconnectCore/Transpiler.cs
+++ b/MtconnectTranspiler.Sinks.MtconnectCore/Transpiler.cs
@@ -5,9 +5,14 @@ using MtconnectTranspiler.Sinks.CSharp;
 using MtconnectTranspiler.Sinks.CSharp.Models;
 using MtconnectTranspiler.Sinks.MtconnectCore.Models;
 using MtconnectTranspiler.Xmi.UML;
+using Scriban.Runtime;
 
 namespace MtconnectTranspiler.Sinks.MtconnectCore
 {
+    public class CategoryFunctions : ScriptObject
+    {
+        public static bool CategoryContains(MtconnectCoreEnum @enum, EnumItem item) => @enum.SubTypes.ContainsKey(item.Name);
+    }
     internal class Transpiler : CsharpTranspiler
     {
         /// <summary>
@@ -21,6 +26,8 @@ namespace MtconnectTranspiler.Sinks.MtconnectCore
             _logger?.LogInformation("Received MTConnectModel, beginning transpilation");
 
             Model.SetValue("model", model, true);
+
+            base.TemplateContext.PushGlobal(new CategoryFunctions());
 
             const string DataItemNamespace = "MtconnectCore.Standard.Contracts.Enums.Devices.DataItemTypes";
             List<MtconnectCoreEnum> dataItemTypes = new List<MtconnectCoreEnum>();
@@ -60,7 +67,7 @@ namespace MtconnectTranspiler.Sinks.MtconnectCore
                     if (subTypes.ContainsKey(type.Name))
                     {
                         // Register type as having a subType in the CATEGORY enum
-                        if (categoryEnum.SubTypes.ContainsKey(type.Name)) categoryEnum.SubTypes.Add(type.Name, $"{type.Name}SubTypes");
+                        if (!categoryEnum.SubTypes.ContainsKey(type.Name)) categoryEnum.SubTypes.Add(ScribanHelperMethods.ToUpperSnakeCode(type.Name), $"{type.Name}SubTypes");
 
                         var typeSubTypes = subTypes[type.Name];
                         var subTypeEnum = new MtconnectCoreEnum(model, type, $"{type.Name}SubTypes") { Namespace = DataItemNamespace };

--- a/MtconnectTranspiler.Sinks.MtconnectCore/Transpiler.cs
+++ b/MtconnectTranspiler.Sinks.MtconnectCore/Transpiler.cs
@@ -59,6 +59,9 @@ namespace MtconnectTranspiler.Sinks.MtconnectCore
 
                     if (subTypes.ContainsKey(type.Name))
                     {
+                        // Register type as having a subType in the CATEGORY enum
+                        if (categoryEnum.SubTypes.ContainsKey(type.Name)) categoryEnum.SubTypes.Add(type.Name, $"{type.Name}SubTypes");
+
                         var typeSubTypes = subTypes[type.Name];
                         var subTypeEnum = new MtconnectCoreEnum(model, type, $"{type.Name}SubTypes") { Namespace = DataItemNamespace };
 


### PR DESCRIPTION
Implemented SubType validation on DataItems of a Devices document. Updated the transpiler to produce the references between type and subTypes. Updated the DataItem class to look-up possible subType definitions by using the new `ObservationalSubType` attribute.