### PR TITLE
DataItem Value Validation

### DIFF
--- a/MtconnectCore/MtconnectCore.csproj
+++ b/MtconnectCore/MtconnectCore.csproj
@@ -20,7 +20,7 @@
     <PackageReleaseNotes>Changed the methodology for producing validation results. Errors were no longer bubbling up to the root document.</PackageReleaseNotes>
     <AssemblyVersion></AssemblyVersion>
     <FileVersion></FileVersion>
-    <Version>2.1.0.2</Version>
+    <Version>2.1.0.3</Version>
   </PropertyGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)'=='net45'">

--- a/MtconnectCore/MtconnectCore.xml
+++ b/MtconnectCore/MtconnectCore.xml
@@ -6755,17 +6755,17 @@
         </member>
         <member name="T:MtconnectCore.Standard.Contracts.Enums.Streams.ActuatorStateValues">
             <summary>
-            Available values for EVENT element <see cref="F:MtconnectCore.Standard.Contracts.Enums.Devices.DataItemTypes.EventTypes.ACTUATOR_STATE"/>
+            View in the MTConnect Model browser <seealso href="https://model.mtconnect.org/#Enumeration__">model.mtconnect.org</seealso>
             </summary>
         </member>
         <member name="F:MtconnectCore.Standard.Contracts.Enums.Streams.ActuatorStateValues.ACTIVE">
             <summary>
-            The actuator is operating or active
+            <see cref="!:Actuator">Actuator</see> is operating.
             </summary>
         </member>
         <member name="F:MtconnectCore.Standard.Contracts.Enums.Streams.ActuatorStateValues.INACTIVE">
             <summary>
-            The actuator is not operating or inactive
+            <see cref="!:Actuator">Actuator</see> is not operating.
             </summary>
         </member>
         <member name="F:MtconnectCore.Standard.Contracts.Enums.Streams.ApplicationCategoryTypes.ASSEMBLY">
@@ -6950,117 +6950,142 @@
         </member>
         <member name="T:MtconnectCore.Standard.Contracts.Enums.Streams.AvailabilityValues">
             <summary>
-            Available values for EVENT element <see cref="F:MtconnectCore.Standard.Contracts.Enums.Devices.DataItemTypes.EventTypes.AVAILABILITY"/>
+            View in the MTConnect Model browser <seealso href="https://model.mtconnect.org/#Enumeration__">model.mtconnect.org</seealso>
             </summary>
         </member>
         <member name="F:MtconnectCore.Standard.Contracts.Enums.Streams.AvailabilityValues.AVAILABLE">
             <summary>
-            The component is available.
+            data source is active and capable of providing data.
             </summary>
         </member>
         <member name="F:MtconnectCore.Standard.Contracts.Enums.Streams.AvailabilityValues.UNAVAILABLE">
             <summary>
-            The component is not available.
+            data source is either inactive or not capable of providing data.
             </summary>
         </member>
         <member name="T:MtconnectCore.Standard.Contracts.Enums.Streams.AxisCouplingValues">
             <summary>
-            Available values for EVENT element <see cref="F:MtconnectCore.Standard.Contracts.Enums.Devices.DataItemTypes.EventTypes.AXIS_COUPLING"/>
+            View in the MTConnect Model browser <seealso href="https://model.mtconnect.org/#Enumeration__">model.mtconnect.org</seealso>
             </summary>
         </member>
         <member name="F:MtconnectCore.Standard.Contracts.Enums.Streams.AxisCouplingValues.TANDEM">
             <summary>
-            The axes are physically connected to each other and must  operate as a single unit.
+            axes are physically connected to each other and operate as a single unit.
             </summary>
         </member>
         <member name="F:MtconnectCore.Standard.Contracts.Enums.Streams.AxisCouplingValues.SYNCHRONOUS">
             <summary>
-            The axes are coupled and are operating together in  lockstep.
+            axes are not physically connected to each other but are operating together in lockstep.
             </summary>
         </member>
         <member name="F:MtconnectCore.Standard.Contracts.Enums.Streams.AxisCouplingValues.MASTER">
             <summary>
-            The axis is the master of the CoupledAxes
+            axis is the master of the <see cref="!:CoupledAxes">CoupledAxes</see>.
             </summary>
         </member>
         <member name="F:MtconnectCore.Standard.Contracts.Enums.Streams.AxisCouplingValues.SLAVE">
             <summary>
-            The axis is a slave of the CoupledAxes
+            axis is a slave to the <see cref="!:CoupledAxes">CoupledAxes</see>.
             </summary>
         </member>
         <member name="T:MtconnectCore.Standard.Contracts.Enums.Streams.AxisInterlockValues">
             <summary>
-            Available values for EVENT element <see cref="F:MtconnectCore.Standard.Contracts.Enums.Devices.DataItemTypes.EventTypes.AXIS_INTERLOCK"/>
+            View in the MTConnect Model browser <seealso href="https://model.mtconnect.org/#Enumeration__">model.mtconnect.org</seealso>
             </summary>
         </member>
         <member name="F:MtconnectCore.Standard.Contracts.Enums.Streams.AxisInterlockValues.ACTIVE">
             <summary>
-            The axis lockout function is activated power has been removed from the axis, and the axis is allowed to move freely.
+            axis lockout function is activated, power has been removed from the axis, and the axis is allowed to move freely.
             </summary>
         </member>
         <member name="F:MtconnectCore.Standard.Contracts.Enums.Streams.AxisInterlockValues.INACTIVE">
             <summary>
-            The axis lockout function has not  been activated, the axis may be powered, and the axis is capable of being controlled by another component.
+            axis lockout function has not been activated, the axis may be powered, and the axis is capable of being controlled by another component.
             </summary>
         </member>
         <member name="T:MtconnectCore.Standard.Contracts.Enums.Streams.AxisStateValues">
             <summary>
-            Available values for EVENT element <see cref="F:MtconnectCore.Standard.Contracts.Enums.Devices.DataItemTypes.EventTypes.AXIS_STATE"/>
+            View in the MTConnect Model browser <seealso href="https://model.mtconnect.org/#Enumeration__">model.mtconnect.org</seealso>
             </summary>
         </member>
         <member name="F:MtconnectCore.Standard.Contracts.Enums.Streams.AxisStateValues.HOME">
             <summary>
-            The axis is in its home position.
+            axis is in its home position.
             </summary>
         </member>
         <member name="F:MtconnectCore.Standard.Contracts.Enums.Streams.AxisStateValues.TRAVEL">
             <summary>
-            The axis is in motion
+            axis is in motion.
             </summary>
         </member>
         <member name="F:MtconnectCore.Standard.Contracts.Enums.Streams.AxisStateValues.PARKED">
             <summary>
-            The axis has been moved to a fixed  position and is being maintained in that position either electrically or mechanically. Action is required to release the axis from this position.
+            axis has been moved to a fixed position and is being maintained in that position either electrically or mechanically.   Action is required to release the axis from this position.
             </summary>
         </member>
         <member name="F:MtconnectCore.Standard.Contracts.Enums.Streams.AxisStateValues.STOPPED">
             <summary>
-            The axis is stopped
+            axis is stopped.
+            </summary>
+        </member>
+        <member name="T:MtconnectCore.Standard.Contracts.Enums.Streams.BatteryStateValues">
+            <summary>
+            View in the MTConnect Model browser <seealso href="https://model.mtconnect.org/#Enumeration__">model.mtconnect.org</seealso>
+            </summary>
+        </member>
+        <member name="F:MtconnectCore.Standard.Contracts.Enums.Streams.BatteryStateValues.CHARGED">
+            <summary>
+            <see cref="!:Component">Component</see> is at it's maximum rated charge level.
+            </summary>
+        </member>
+        <member name="F:MtconnectCore.Standard.Contracts.Enums.Streams.BatteryStateValues.CHARGING">
+            <summary>
+            <see cref="!:Component">Component</see>'s charge is increasing.
+            </summary>
+        </member>
+        <member name="F:MtconnectCore.Standard.Contracts.Enums.Streams.BatteryStateValues.DISCHARGING">
+            <summary>
+            <see cref="!:Component">Component</see>'s charge is decreasing.
+            </summary>
+        </member>
+        <member name="F:MtconnectCore.Standard.Contracts.Enums.Streams.BatteryStateValues.DISCHARGED">
+            <summary>
+            <see cref="!:Component">Component</see> is at it's minimum charge level.
             </summary>
         </member>
         <member name="T:MtconnectCore.Standard.Contracts.Enums.Streams.ChuckInterlockValues">
             <summary>
-            Available values for EVENT element <see cref="F:MtconnectCore.Standard.Contracts.Enums.Devices.DataItemTypes.EventTypes.CHUCK_INTERLOCK"/>
+            View in the MTConnect Model browser <seealso href="https://model.mtconnect.org/#Enumeration__">model.mtconnect.org</seealso>
             </summary>
         </member>
         <member name="F:MtconnectCore.Standard.Contracts.Enums.Streams.ChuckInterlockValues.ACTIVE">
             <summary>
-            The chuck cannot be operated.
+            chuck cannot be unclamped.
             </summary>
         </member>
         <member name="F:MtconnectCore.Standard.Contracts.Enums.Streams.ChuckInterlockValues.INACTIVE">
             <summary>
-            The chuck can be operated.
+            chuck can be unclamped.
             </summary>
         </member>
         <member name="T:MtconnectCore.Standard.Contracts.Enums.Streams.ChuckStateValues">
             <summary>
-            Available values for EVENT element <see cref="F:MtconnectCore.Standard.Contracts.Enums.Devices.DataItemTypes.EventTypes.CHUCK_STATE"/>
+            View in the MTConnect Model browser <seealso href="https://model.mtconnect.org/#Enumeration__">model.mtconnect.org</seealso>
             </summary>
         </member>
         <member name="F:MtconnectCore.Standard.Contracts.Enums.Streams.ChuckStateValues.OPEN">
             <summary>
-            The chuck is open to the point of a positive confirmation
+            <see cref="!:Chuck">Chuck</see> is open to the point of a positive confirmation.
             </summary>
         </member>
         <member name="F:MtconnectCore.Standard.Contracts.Enums.Streams.ChuckStateValues.CLOSED">
             <summary>
-            The chuck is closed to the point of a positive  confirmation
+            <see cref="!:Chuck">Chuck</see> is closed to the point of a positive confirmation.
             </summary>
         </member>
         <member name="F:MtconnectCore.Standard.Contracts.Enums.Streams.ChuckStateValues.UNLATCHED">
             <summary>
-            The chuck is not closed to the point of a positive  confirmation and not open to the point of a positive confirmation
+            <see cref="!:Chuck">Chuck</see> is not closed to the point of a positive confirmation and not open to the point of a positive confirmation.   It is in an intermediate position.
             </summary>
         </member>
         <member name="T:MtconnectCore.Standard.Contracts.Enums.Streams.CompositionStateActionValues">
@@ -7155,77 +7180,72 @@
         </member>
         <member name="T:MtconnectCore.Standard.Contracts.Enums.Streams.ConnectionStatusValues">
             <summary>
-            Available values for EVENT element <see cref="F:MtconnectCore.Standard.Contracts.Enums.Devices.DataItemTypes.EventTypes.CONNECTION_STATUS"/>
+            View in the MTConnect Model browser <seealso href="https://model.mtconnect.org/#Enumeration__">model.mtconnect.org</seealso>
             </summary>
         </member>
         <member name="F:MtconnectCore.Standard.Contracts.Enums.Streams.ConnectionStatusValues.CLOSED">
             <summary>
-            Represents no connection at all.
+            no connection at all.
             </summary>
         </member>
         <member name="F:MtconnectCore.Standard.Contracts.Enums.Streams.ConnectionStatusValues.LISTEN">
             <summary>
-            Represents the Agent waiting for a connection request from an Adapter.
+            <i>agent</i> is waiting for a connection request from an <i>adapter</i>.
             </summary>
         </member>
         <member name="F:MtconnectCore.Standard.Contracts.Enums.Streams.ConnectionStatusValues.ESTABLISHED">
             <summary>
-            Represents an open connection. The normal state for the data transfer phase of the connection.
+            open connection.  The normal state for the data transfer phase of the connection.
             </summary>
         </member>
         <member name="T:MtconnectCore.Standard.Contracts.Enums.Streams.ControllerModeOverrideValues">
             <summary>
-            Available values for EVENT element <see cref="F:MtconnectCore.Standard.Contracts.Enums.Devices.DataItemTypes.EventTypes.CONTROLLER_MODE_OVERRIDE"/>
+            View in the MTConnect Model browser <seealso href="https://model.mtconnect.org/#Enumeration__">model.mtconnect.org</seealso>
             </summary>
         </member>
         <member name="F:MtconnectCore.Standard.Contracts.Enums.Streams.ControllerModeOverrideValues.ON">
             <summary>
-            The indicator of the  ControllerModeOverride is in the ON state and the mode override is active.
+            <see cref="!:ControllerModeOverride">ControllerModeOverride</see> is in the <c>ON</c> state and the mode override is active.
             </summary>
         </member>
         <member name="F:MtconnectCore.Standard.Contracts.Enums.Streams.ControllerModeOverrideValues.OFF">
             <summary>
-            The indicator of the  ControllerModeOverride is in the OFF state and the mode override is inactive
+            <see cref="!:ControllerModeOverride">ControllerModeOverride</see> is in the <c>OFF</c> state and the mode override is inactive.
             </summary>
         </member>
         <member name="T:MtconnectCore.Standard.Contracts.Enums.Streams.ControllerModeValues">
             <summary>
-            Available values for EVENT element <see cref="F:MtconnectCore.Standard.Contracts.Enums.Devices.DataItemTypes.EventTypes.CONTROLLER_MODE"/>
+            View in the MTConnect Model browser <seealso href="https://model.mtconnect.org/#Enumeration__">model.mtconnect.org</seealso>
             </summary>
         </member>
         <member name="F:MtconnectCore.Standard.Contracts.Enums.Streams.ControllerModeValues.AUTOMATIC">
             <summary>
-            The controller is configured to automatically execute a  program.
-            </summary>
-        </member>
-        <member name="F:MtconnectCore.Standard.Contracts.Enums.Streams.ControllerModeValues.SEMI_AUTOMATIC">
-            <summary>
-            The controller is operating in a single cycle, single block,  or single step mode.
+            <see cref="!:Controller">Controller</see> is configured to automatically execute a program.
             </summary>
         </member>
         <member name="F:MtconnectCore.Standard.Contracts.Enums.Streams.ControllerModeValues.MANUAL">
             <summary>
-            The controller is under manual control by the operator.
+            <see cref="!:Controller">Controller</see> is not executing an active program.   It is capable of receiving instructions from an external source – typically an operator. The <see cref="!:Controller">Controller</see> executes operations based on the instructions received from the external source.
             </summary>
         </member>
         <member name="F:MtconnectCore.Standard.Contracts.Enums.Streams.ControllerModeValues.MANUAL_DATA_INPUT">
             <summary>
-            The operator can enter operations for the controller to  perform. There is no current program being executed.
+            operator can enter a series of operations for the <see cref="!:Controller">Controller</see> to perform.  The <see cref="!:Controller">Controller</see> will execute this specific series of operations and then stop.
+            </summary>
+        </member>
+        <member name="F:MtconnectCore.Standard.Contracts.Enums.Streams.ControllerModeValues.SEMI_AUTOMATIC">
+            <summary>
+            <see cref="!:Controller">Controller</see> is operating in a mode that restricts the active program from processing its next process step without operator intervention.
             </summary>
         </member>
         <member name="F:MtconnectCore.Standard.Contracts.Enums.Streams.ControllerModeValues.EDIT">
             <summary>
-            The controller is currently editing a program in the  foreground.
-            </summary>
-        </member>
-        <member name="F:MtconnectCore.Standard.Contracts.Enums.Streams.ControllerModeValues.SINGLE_BLOCK">
-            <summary>
-            The machine is executing single block or instruction.
+            <see cref="!:Controller">Controller</see> is currently functioning as a programming device and is not capable of executing an active program.
             </summary>
         </member>
         <member name="F:MtconnectCore.Standard.Contracts.Enums.Streams.ControllerModeValues.FEED_HOLD">
             <summary>
-            The axes of the device are commanded to stop, but the  spindle continues to function.
+            axes of the device are commanded to stop, but the spindle continues to function.
             </summary>
         </member>
         <member name="T:MtconnectCore.Standard.Contracts.Enums.Streams.DirectionLinearValues">
@@ -7263,24 +7283,47 @@
             No direction.
             </summary>
         </member>
+        <member name="T:MtconnectCore.Standard.Contracts.Enums.Streams.DirectionValues">
+            <summary>
+            View in the MTConnect Model browser <seealso href="https://model.mtconnect.org/#Enumeration__">model.mtconnect.org</seealso>
+            </summary>
+        </member>
+        <member name="F:MtconnectCore.Standard.Contracts.Enums.Streams.DirectionValues.CLOCKWISE">
+            <summary>
+            clockwise rotation using the right-hand rule.
+            </summary>
+        </member>
+        <member name="F:MtconnectCore.Standard.Contracts.Enums.Streams.DirectionValues.COUNTER_CLOCKWISE">
+            <summary>
+            counter-clockwise rotation using the right-hand rule.
+            </summary>
+        </member>
+        <member name="F:MtconnectCore.Standard.Contracts.Enums.Streams.DirectionValues.POSITIVE">
+            <summary>
+            </summary>
+        </member>
+        <member name="F:MtconnectCore.Standard.Contracts.Enums.Streams.DirectionValues.NEGATIVE">
+            <summary>
+            </summary>
+        </member>
         <member name="T:MtconnectCore.Standard.Contracts.Enums.Streams.DoorStateValues">
             <summary>
-            Available values for EVENT element <see cref="F:MtconnectCore.Standard.Contracts.Enums.Devices.DataItemTypes.EventTypes.DOOR_STATE"/>
+            View in the MTConnect Model browser <seealso href="https://model.mtconnect.org/#Enumeration__">model.mtconnect.org</seealso>
             </summary>
         </member>
         <member name="F:MtconnectCore.Standard.Contracts.Enums.Streams.DoorStateValues.OPEN">
             <summary>
-            The door is opened.
+            <see cref="!:Door">Door</see> is open to the point of a positive confirmation.
             </summary>
         </member>
         <member name="F:MtconnectCore.Standard.Contracts.Enums.Streams.DoorStateValues.CLOSED">
             <summary>
-            The door is closed.
+            <see cref="!:Door">Door</see> is closed to the point of a positive confirmation.
             </summary>
         </member>
         <member name="F:MtconnectCore.Standard.Contracts.Enums.Streams.DoorStateValues.UNLATCHED">
             <summary>
-            The door is not closed to the point of a positive  confirmation and not open to the point of a positive confirmation
+            <see cref="!:Door">Door</see> is not closed to the point of a positive confirmation and not open to the point of a positive confirmation.   It is in an intermediate position.
             </summary>
         </member>
         <member name="F:MtconnectCore.Standard.Contracts.Enums.Streams.Elements.AbstractFileElements.FILE_PROPERTIES">
@@ -7355,102 +7398,97 @@
         </member>
         <member name="T:MtconnectCore.Standard.Contracts.Enums.Streams.EmergencyStopValues">
             <summary>
-            Available values for EVENT element <see cref="F:MtconnectCore.Standard.Contracts.Enums.Devices.DataItemTypes.EventTypes.EMERGENCY_STOP"/>
+            View in the MTConnect Model browser <seealso href="https://model.mtconnect.org/#Enumeration__">model.mtconnect.org</seealso>
             </summary>
         </member>
         <member name="F:MtconnectCore.Standard.Contracts.Enums.Streams.EmergencyStopValues.ARMED">
             <summary>
-            The circuit is complete and the device is operating.
+            emergency stop circuit is complete and the piece of equipment, component, or composition is allowed to operate. 
             </summary>
         </member>
         <member name="F:MtconnectCore.Standard.Contracts.Enums.Streams.EmergencyStopValues.TRIGGERED">
             <summary>
-            The circuit is open and the device must cease operation.
+            operation of the piece of equipment, component, or composition is inhibited.
             </summary>
         </member>
         <member name="T:MtconnectCore.Standard.Contracts.Enums.Streams.EndOfBarValues">
             <summary>
-            Available values for EVENT element <see cref="F:MtconnectCore.Standard.Contracts.Enums.Devices.DataItemTypes.EventTypes.END_OF_BAR"/>
+            View in the MTConnect Model browser <seealso href="https://model.mtconnect.org/#Enumeration__">model.mtconnect.org</seealso>
             </summary>
         </member>
         <member name="F:MtconnectCore.Standard.Contracts.Enums.Streams.EndOfBarValues.YES">
             <summary>
-            The end of bar has been reached
+            <see cref="!:EndOfBar">EndOfBar</see> has been reached.
             </summary>
         </member>
         <member name="F:MtconnectCore.Standard.Contracts.Enums.Streams.EndOfBarValues.NO">
             <summary>
-            The end of bar has not been reached
+            <see cref="!:EndOfBar">EndOfBar</see> has not been reached.
             </summary>
         </member>
         <member name="T:MtconnectCore.Standard.Contracts.Enums.Streams.EquipmentModeValues">
             <summary>
-            Available values for EVENT element <see cref="F:MtconnectCore.Standard.Contracts.Enums.Devices.DataItemTypes.EventTypes.EQUIPMENT_MODE"/>
+            View in the MTConnect Model browser <seealso href="https://model.mtconnect.org/#Enumeration__">model.mtconnect.org</seealso>
             </summary>
         </member>
         <member name="F:MtconnectCore.Standard.Contracts.Enums.Streams.EquipmentModeValues.ON">
             <summary>
-            The equipment is functioning in the mode  designated by the subType
+            equipment is functioning in the mode designated by the <c>subType</c>.
             </summary>
         </member>
         <member name="F:MtconnectCore.Standard.Contracts.Enums.Streams.EquipmentModeValues.OFF">
             <summary>
-            The equipment is not functioning in th mode designated by the subType.
+            equipment is not functioning in the mode designated by the <c>subType</c>.
             </summary>
         </member>
         <member name="T:MtconnectCore.Standard.Contracts.Enums.Streams.ExecutionValues">
             <summary>
-            Available values for EVENT element <see cref="F:MtconnectCore.Standard.Contracts.Enums.Devices.DataItemTypes.EventTypes.EXECUTION"/>
+            View in the MTConnect Model browser <seealso href="https://model.mtconnect.org/#Enumeration__">model.mtconnect.org</seealso>
             </summary>
         </member>
         <member name="F:MtconnectCore.Standard.Contracts.Enums.Streams.ExecutionValues.READY">
             <summary>
-            The controller is ready to execute. It is currently idle.
+            <see cref="!:Component">Component</see> is ready to execute instructions.  It is currently idle.
             </summary>
         </member>
         <member name="F:MtconnectCore.Standard.Contracts.Enums.Streams.ExecutionValues.ACTIVE">
             <summary>
-            The controller is actively executing an instruction.
+            <see cref="!:Component">Component</see> is actively executing an instruction.
             </summary>
         </member>
         <member name="F:MtconnectCore.Standard.Contracts.Enums.Streams.ExecutionValues.INTERRUPTED">
             <summary>
-            The operator or the program has paused execution and is waiting to be continued.
-            </summary>
-        </member>
-        <member name="F:MtconnectCore.Standard.Contracts.Enums.Streams.ExecutionValues.WAIT">
-            <summary>
-            The execution of the controller’s program is suspended while a secondary operation is executing or completing. Execution will resume automatically once the secondary operation is completed.
+            <see cref="!:Component">Component</see> suspends the execution of the program due to an external signal.  Action is required to resume execution.
             </summary>
         </member>
         <member name="F:MtconnectCore.Standard.Contracts.Enums.Streams.ExecutionValues.FEED_HOLD">
             <summary>
-            The controller has is in a feed hold and motion has  been stopped.
+            motion of the active axes are commanded to stop at their current position.
             </summary>
         </member>
         <member name="F:MtconnectCore.Standard.Contracts.Enums.Streams.ExecutionValues.STOPPED">
             <summary>
-            The controller has been stopped.
+            <see cref="!:Component">Component</see> program is not <c>READY</c> to execute.
             </summary>
         </member>
         <member name="F:MtconnectCore.Standard.Contracts.Enums.Streams.ExecutionValues.OPTIONAL_STOP">
             <summary>
-            The controller’s program has  been intentionally stopped using an M01 or similar command.The program may be stopped at the designated location based upon the state of a secondary indication provided to the controller indicating whether the program execution must be stopped at this location or program execution should continue.
+            command from the program has intentionally interrupted execution.  The <see cref="!:Component">Component</see> <b>MAY</b> have another state that indicates if the execution is interrupted or the execution ignores the interrupt instruction.
             </summary>
         </member>
         <member name="F:MtconnectCore.Standard.Contracts.Enums.Streams.ExecutionValues.PROGRAM_STOPPED">
             <summary>
-            The program has been stopped.
+            command from the program has intentionally interrupted execution.  Action is required to resume execution.
             </summary>
         </member>
         <member name="F:MtconnectCore.Standard.Contracts.Enums.Streams.ExecutionValues.PROGRAM_COMPLETED">
             <summary>
-            The program has completed execution.
+            program completed execution.
             </summary>
         </member>
-        <member name="F:MtconnectCore.Standard.Contracts.Enums.Streams.ExecutionValues.PROGRAM_OPTIONAL_STOP">
+        <member name="F:MtconnectCore.Standard.Contracts.Enums.Streams.ExecutionValues.WAIT">
             <summary>
-            The program has been intentionally optionally stopped using an M01 or similar code.
+            <see cref="!:Component">Component</see> suspends execution while a secondary operation executes.  Execution resumes automatically once the secondary operation completes.
             </summary>
         </member>
         <member name="F:MtconnectCore.Standard.Contracts.Enums.Streams.FileStateValues.EXPERIMENTAL">
@@ -7470,32 +7508,32 @@
         </member>
         <member name="T:MtconnectCore.Standard.Contracts.Enums.Streams.FunctionalModeValues">
             <summary>
-            Available values for EVENT element <see cref="F:MtconnectCore.Standard.Contracts.Enums.Devices.DataItemTypes.EventTypes.FUNCTIONAL_MODE"/>
+            View in the MTConnect Model browser <seealso href="https://model.mtconnect.org/#Enumeration__">model.mtconnect.org</seealso>
             </summary>
         </member>
         <member name="F:MtconnectCore.Standard.Contracts.Enums.Streams.FunctionalModeValues.PRODUCTION">
             <summary>
-            The device is ready for automated production.
+            <see cref="!:Component">Component</see> is currently producing product, ready to produce product, or its current intended use is to be producing product.
             </summary>
         </member>
         <member name="F:MtconnectCore.Standard.Contracts.Enums.Streams.FunctionalModeValues.SETUP">
             <summary>
-            The device is being setup for a new part type.
+            <see cref="!:Component">Component</see> is not currently producing product.   It is being prepared or modified to begin production of product.
             </summary>
         </member>
         <member name="F:MtconnectCore.Standard.Contracts.Enums.Streams.FunctionalModeValues.TEARDOWN">
             <summary>
-            The current setup is being removed from the device.
+            <see cref="!:Component">Component</see> is not currently producing product.  Typically, it has completed the production of a product and is being modified or returned to a neutral state such that it may then be prepared to begin production of a different product.
             </summary>
         </member>
         <member name="F:MtconnectCore.Standard.Contracts.Enums.Streams.FunctionalModeValues.MAINTENANCE">
             <summary>
-            The device is being repaired or routine service is being  performed.
+            <see cref="!:Component">Component</see> is not currently producing product.  It is currently being repaired, waiting to be repaired, or has not yet been returned to a normal production status after maintenance has been performed.
             </summary>
         </member>
         <member name="F:MtconnectCore.Standard.Contracts.Enums.Streams.FunctionalModeValues.PROCESS_DEVELOPMENT">
             <summary>
-            The device is being used to prove-out a new process.
+            <see cref="!:Component">Component</see> is being used to prove-out a new process, testing of equipment or processes, or any other active use that does not result in the production of product.
             </summary>
         </member>
         <member name="T:MtconnectCore.Standard.Contracts.Enums.Streams.InterfaceStateValues">
@@ -7513,124 +7551,287 @@
             The interface is not operational.
             </summary>
         </member>
+        <member name="T:MtconnectCore.Standard.Contracts.Enums.Streams.LeakDetectValues">
+            <summary>
+            View in the MTConnect Model browser <seealso href="https://model.mtconnect.org/#Enumeration__">model.mtconnect.org</seealso>
+            </summary>
+        </member>
+        <member name="F:MtconnectCore.Standard.Contracts.Enums.Streams.LeakDetectValues.DETECTED">
+            <summary>
+            leak is currently being detected.
+            </summary>
+        </member>
+        <member name="F:MtconnectCore.Standard.Contracts.Enums.Streams.LeakDetectValues.NOT_DETECTED">
+            <summary>
+            leak is currently not being detected.
+            </summary>
+        </member>
+        <member name="T:MtconnectCore.Standard.Contracts.Enums.Streams.LockStateValues">
+            <summary>
+            View in the MTConnect Model browser <seealso href="https://model.mtconnect.org/#Enumeration__">model.mtconnect.org</seealso>
+            </summary>
+        </member>
+        <member name="F:MtconnectCore.Standard.Contracts.Enums.Streams.LockStateValues.LOCKED">
+            <summary>
+            mechanism is engaged and preventing the associated <see cref="!:Component">Component</see> from being opened or operated.
+            </summary>
+        </member>
+        <member name="F:MtconnectCore.Standard.Contracts.Enums.Streams.LockStateValues.UNLOCKED">
+            <summary>
+            mechanism is disengaged and the associated <see cref="!:Component">Component</see> is able to be opened or operated.
+            </summary>
+        </member>
+        <member name="T:MtconnectCore.Standard.Contracts.Enums.Streams.OperatingModeValues">
+            <summary>
+            View in the MTConnect Model browser <seealso href="https://model.mtconnect.org/#Enumeration__">model.mtconnect.org</seealso>
+            </summary>
+        </member>
+        <member name="F:MtconnectCore.Standard.Contracts.Enums.Streams.OperatingModeValues.AUTOMATIC">
+            <summary>
+            automatically execute instructions from a recipe or program.  > Note: Setpoint comes from a recipe.
+            </summary>
+        </member>
+        <member name="F:MtconnectCore.Standard.Contracts.Enums.Streams.OperatingModeValues.MANUAL">
+            <summary>
+            execute instructions from an external agent or person.  > Note 1 to entry: Valve or switch is manipulated by an agent/person.  > Note 2 to entry: Direct control of the PID output. % of the range: A user manually sets the % output, not the setpoint.
+            </summary>
+        </member>
+        <member name="F:MtconnectCore.Standard.Contracts.Enums.Streams.OperatingModeValues.SEMI_AUTOMATIC">
+            <summary>
+            executes a single instruction from a recipe or program.  > Note 1 to entry: Setpoint is entered and fixed, but the PID is controlling.  > Note 2 to entry: Still goes through the PID control system.  > Note 3 to entry: Manual fixed entry from a recipe.
+            </summary>
+        </member>
+        <member name="T:MtconnectCore.Standard.Contracts.Enums.Streams.PartCountTypeValues">
+            <summary>
+            View in the MTConnect Model browser <seealso href="https://model.mtconnect.org/#Enumeration__">model.mtconnect.org</seealso>
+            </summary>
+        </member>
+        <member name="F:MtconnectCore.Standard.Contracts.Enums.Streams.PartCountTypeValues.EACH">
+            <summary>
+            count is of individual items.
+            </summary>
+        </member>
+        <member name="F:MtconnectCore.Standard.Contracts.Enums.Streams.PartCountTypeValues.BATCH">
+            <summary>
+            pre-specified group of items.
+            </summary>
+        </member>
         <member name="T:MtconnectCore.Standard.Contracts.Enums.Streams.PartDetectValues">
             <summary>
-            Available values for EVENT element <see cref="F:MtconnectCore.Standard.Contracts.Enums.Devices.DataItemTypes.EventTypes.PART_DETECT"/>
+            View in the MTConnect Model browser <seealso href="https://model.mtconnect.org/#Enumeration__">model.mtconnect.org</seealso>
             </summary>
         </member>
         <member name="F:MtconnectCore.Standard.Contracts.Enums.Streams.PartDetectValues.PRESENT">
             <summary>
-            If a part or work piece has been detected or is present.
+            part or work piece is detected or is present.
             </summary>
         </member>
         <member name="F:MtconnectCore.Standard.Contracts.Enums.Streams.PartDetectValues.NOT_PRESENT">
             <summary>
-            If a part or work piece is not detected or is not present.
+            part or work piece is not detected or is not present.
+            </summary>
+        </member>
+        <member name="T:MtconnectCore.Standard.Contracts.Enums.Streams.PartProcessingStateValues">
+            <summary>
+            View in the MTConnect Model browser <seealso href="https://model.mtconnect.org/#Enumeration__">model.mtconnect.org</seealso>
+            </summary>
+        </member>
+        <member name="F:MtconnectCore.Standard.Contracts.Enums.Streams.PartProcessingStateValues.NEEDS_PROCESSING">
+            <summary>
+            part occurrence is not actively being processed, but the processing has not ended.   Processing requirements exist that have not yet been fulfilled. This is the default entry state when the part occurrence is originally received. In some cases, the part occurrence may return to this state while it waits for additional processing to be performed.
+            </summary>
+        </member>
+        <member name="F:MtconnectCore.Standard.Contracts.Enums.Streams.PartProcessingStateValues.IN_PROCESS">
+            <summary>
+            part occurrence is actively being processed.
+            </summary>
+        </member>
+        <member name="F:MtconnectCore.Standard.Contracts.Enums.Streams.PartProcessingStateValues.PROCESSING_ENDED">
+            <summary>
+            part occurrence is no longer being processed.   A general state when the reason for termination is unknown.
+            </summary>
+        </member>
+        <member name="F:MtconnectCore.Standard.Contracts.Enums.Streams.PartProcessingStateValues.PROCESSING_ENDED_COMPLETE">
+            <summary>
+            part occurrence has completed processing successfully.
+            </summary>
+        </member>
+        <member name="F:MtconnectCore.Standard.Contracts.Enums.Streams.PartProcessingStateValues.PROCESSING_ENDED_STOPPED">
+            <summary>
+            process has been stopped during the processing.   The part occurrence will require special treatment.
+            </summary>
+        </member>
+        <member name="F:MtconnectCore.Standard.Contracts.Enums.Streams.PartProcessingStateValues.PROCESSING_ENDED_ABORTED">
+            <summary>
+            processing of the part occurrence has come to a premature end.
+            </summary>
+        </member>
+        <member name="F:MtconnectCore.Standard.Contracts.Enums.Streams.PartProcessingStateValues.PROCESSING_ENDED_LOST">
+            <summary>
+            terminal state when the part occurrence has been removed from the equipment by an external entity and it no longer exists at the equipment.
+            </summary>
+        </member>
+        <member name="F:MtconnectCore.Standard.Contracts.Enums.Streams.PartProcessingStateValues.PROCESSING_ENDED_SKIPPED">
+            <summary>
+            part occurrence has been skipped for processing on the piece of equipment.
+            </summary>
+        </member>
+        <member name="F:MtconnectCore.Standard.Contracts.Enums.Streams.PartProcessingStateValues.PROCESSING_ENDED_REJECTED">
+            <summary>
+            part occurrence has been processed completely. However, the processing may have a problem.
+            </summary>
+        </member>
+        <member name="F:MtconnectCore.Standard.Contracts.Enums.Streams.PartProcessingStateValues.WAITING_FOR_TRANSIT">
+            <summary>
+            part occurrence is waiting for transit.
+            </summary>
+        </member>
+        <member name="F:MtconnectCore.Standard.Contracts.Enums.Streams.PartProcessingStateValues.IN_TRANSIT">
+            <summary>
+            part occurrence is being transported to its destination.
+            </summary>
+        </member>
+        <member name="F:MtconnectCore.Standard.Contracts.Enums.Streams.PartProcessingStateValues.TRANSIT_COMPLETE">
+            <summary>
+            part occurrence has been placed at its designated destination.
             </summary>
         </member>
         <member name="T:MtconnectCore.Standard.Contracts.Enums.Streams.PartStatusValues">
             <summary>
-            Available values for EVENT element <see cref="F:MtconnectCore.Standard.Contracts.Enums.Devices.DataItemTypes.EventTypes.PART_STATUS"/>
+            View in the MTConnect Model browser <seealso href="https://model.mtconnect.org/#Enumeration__">model.mtconnect.org</seealso>
             </summary>
         </member>
         <member name="F:MtconnectCore.Standard.Contracts.Enums.Streams.PartStatusValues.PASS">
             <summary>
-            The part does conform to given requirements.
+            part conforms to given requirements.
             </summary>
         </member>
         <member name="F:MtconnectCore.Standard.Contracts.Enums.Streams.PartStatusValues.FAIL">
             <summary>
-            The part does not conform to some given requirements.
+            part does not conform to some given requirements.
             </summary>
         </member>
         <member name="T:MtconnectCore.Standard.Contracts.Enums.Streams.PathModeValues">
             <summary>
-            Available values for EVENT element <see cref="F:MtconnectCore.Standard.Contracts.Enums.Devices.DataItemTypes.EventTypes.PATH_MODE"/>
+            View in the MTConnect Model browser <seealso href="https://model.mtconnect.org/#Enumeration__">model.mtconnect.org</seealso>
             </summary>
         </member>
         <member name="F:MtconnectCore.Standard.Contracts.Enums.Streams.PathModeValues.INDEPENDENT">
             <summary>
-            A set of axes are operating independently and without the  influence of another set of axes.
+            path is operating independently and without the influence of another path.
             </summary>
         </member>
         <member name="F:MtconnectCore.Standard.Contracts.Enums.Streams.PathModeValues.MASTER">
             <summary>
-            The path provides the reference motion from which a  Synchronous or Mirror Path will follow.
+            path provides information or state values that influences the operation of other <see cref="!:DataItem">DataItem</see> of similar type.
             </summary>
         </member>
         <member name="F:MtconnectCore.Standard.Contracts.Enums.Streams.PathModeValues.SYNCHRONOUS">
             <summary>
-            The sets of axes are operating synchronously.
+            physical or logical parts which are not physically connected to each other but are operating together.
             </summary>
         </member>
         <member name="F:MtconnectCore.Standard.Contracts.Enums.Streams.PathModeValues.MIRROR">
             <summary>
-            The sets of axes are mirroring each other.
+            axes associated with the path are mirroring the motion of the <c>MASTER</c> path.
             </summary>
         </member>
         <member name="T:MtconnectCore.Standard.Contracts.Enums.Streams.PowerStateValues">
             <summary>
-            Available values for EVENT element <see cref="F:MtconnectCore.Standard.Contracts.Enums.Devices.DataItemTypes.EventTypes.POWER_STATE"/>
+            View in the MTConnect Model browser <seealso href="https://model.mtconnect.org/#Enumeration__">model.mtconnect.org</seealso>
             </summary>
         </member>
         <member name="F:MtconnectCore.Standard.Contracts.Enums.Streams.PowerStateValues.ON">
             <summary>
-            The power to the component is ON.
+            source of energy for an entity or the enabling signal providing permission for the entity to perform its function(s) is present and active.
             </summary>
         </member>
         <member name="F:MtconnectCore.Standard.Contracts.Enums.Streams.PowerStateValues.OFF">
             <summary>
-            The power to the component is OFF.
+            source of energy for an entity or the enabling signal providing permission for the entity to perform its function(s) is not present or is disconnected.
             </summary>
         </member>
         <member name="T:MtconnectCore.Standard.Contracts.Enums.Streams.PowerStatusValues">
             <summary>
-            Available values for EVENT element <see cref="F:MtconnectCore.Standard.Contracts.Enums.Devices.DataItemTypes.EventTypes.POWER_STATUS"/>
+            View in the MTConnect Model browser <seealso href="https://model.mtconnect.org/#Enumeration__">model.mtconnect.org</seealso>
             </summary>
         </member>
         <member name="F:MtconnectCore.Standard.Contracts.Enums.Streams.PowerStatusValues.ON">
             <summary>
-            The power to the component is ON.
             </summary>
         </member>
         <member name="F:MtconnectCore.Standard.Contracts.Enums.Streams.PowerStatusValues.OFF">
             <summary>
-            The power to the component is OFF.
+            </summary>
+        </member>
+        <member name="T:MtconnectCore.Standard.Contracts.Enums.Streams.ProcessStateValues">
+            <summary>
+            View in the MTConnect Model browser <seealso href="https://model.mtconnect.org/#Enumeration__">model.mtconnect.org</seealso>
+            </summary>
+        </member>
+        <member name="F:MtconnectCore.Standard.Contracts.Enums.Streams.ProcessStateValues.INITIALIZING">
+            <summary>
+            device is preparing to execute the process occurrence.
+            </summary>
+        </member>
+        <member name="F:MtconnectCore.Standard.Contracts.Enums.Streams.ProcessStateValues.READY">
+            <summary>
+            process occurrence is ready to be executed.
+            </summary>
+        </member>
+        <member name="F:MtconnectCore.Standard.Contracts.Enums.Streams.ProcessStateValues.ACTIVE">
+            <summary>
+            process occurrence is actively executing.
+            </summary>
+        </member>
+        <member name="F:MtconnectCore.Standard.Contracts.Enums.Streams.ProcessStateValues.COMPLETE">
+            <summary>
+            process occurrence is now finished.
+            </summary>
+        </member>
+        <member name="F:MtconnectCore.Standard.Contracts.Enums.Streams.ProcessStateValues.INTERRUPTED">
+            <summary>
+            process occurrence has been stopped and may be resumed.
+            </summary>
+        </member>
+        <member name="F:MtconnectCore.Standard.Contracts.Enums.Streams.ProcessStateValues.ABORTED">
+            <summary>
+            process occurrence has come to a premature end and cannot be resumed.
             </summary>
         </member>
         <member name="T:MtconnectCore.Standard.Contracts.Enums.Streams.ProgramEditValues">
             <summary>
-            Available values for EVENT element <see cref="F:MtconnectCore.Standard.Contracts.Enums.Devices.DataItemTypes.EventTypes.PROGRAM_EDIT"/>
+            View in the MTConnect Model browser <seealso href="https://model.mtconnect.org/#Enumeration__">model.mtconnect.org</seealso>
             </summary>
         </member>
         <member name="F:MtconnectCore.Standard.Contracts.Enums.Streams.ProgramEditValues.ACTIVE">
             <summary>
-            A program is currently being edited.
+            <see cref="!:Controller">Controller</see> is in the program edit mode.
             </summary>
         </member>
         <member name="F:MtconnectCore.Standard.Contracts.Enums.Streams.ProgramEditValues.READY">
             <summary>
-            The controller is capable of editing a program, but it is not  currently editing a program.
+            <see cref="!:Controller">Controller</see> is capable of entering the program edit mode and no function is inhibiting a change to that mode.
             </summary>
         </member>
         <member name="F:MtconnectCore.Standard.Contracts.Enums.Streams.ProgramEditValues.NOT_READY">
             <summary>
-            The controller is in a state where it cannot edit a program.
+            <see cref="!:Controller">Controller</see> is being inhibited by a function from entering the program edit mode.
             </summary>
         </member>
         <member name="T:MtconnectCore.Standard.Contracts.Enums.Streams.ProgramLocationTypeValues">
             <summary>
-            Available values for EVENT element <see cref="F:MtconnectCore.Standard.Contracts.Enums.Devices.DataItemTypes.EventTypes.PROGRAM_LOCATION_TYPE"/>
+            View in the MTConnect Model browser <seealso href="https://model.mtconnect.org/#Enumeration__">model.mtconnect.org</seealso>
             </summary>
         </member>
         <member name="F:MtconnectCore.Standard.Contracts.Enums.Streams.ProgramLocationTypeValues.LOCAL">
             <summary>
-            Managed by the controller.
+            managed by the controller.
             </summary>
         </member>
         <member name="F:MtconnectCore.Standard.Contracts.Enums.Streams.ProgramLocationTypeValues.EXTERNAL">
             <summary>
-            Not managed by the controller.
+            not managed by the controller.
             </summary>
         </member>
         <member name="T:MtconnectCore.Standard.Contracts.Enums.Streams.ResetTriggerValues">
@@ -7685,97 +7886,122 @@
         </member>
         <member name="T:MtconnectCore.Standard.Contracts.Enums.Streams.RotaryModeValues">
             <summary>
-            Available values for EVENT element <see cref="F:MtconnectCore.Standard.Contracts.Enums.Devices.DataItemTypes.EventTypes.ROTARY_MODE"/>
+            View in the MTConnect Model browser <seealso href="https://model.mtconnect.org/#Enumeration__">model.mtconnect.org</seealso>
             </summary>
         </member>
         <member name="F:MtconnectCore.Standard.Contracts.Enums.Streams.RotaryModeValues.SPINDLE">
             <summary>
-            The axis is operating like a spindle and spinning.
+            axis is functioning as a spindle.
             </summary>
         </member>
         <member name="F:MtconnectCore.Standard.Contracts.Enums.Streams.RotaryModeValues.INDEX">
             <summary>
-            The axis is indexing to a position.
+            axis is configured to index.
             </summary>
         </member>
         <member name="F:MtconnectCore.Standard.Contracts.Enums.Streams.RotaryModeValues.CONTOUR">
             <summary>
-            The axes is indexing and rotating at a programmed velocity.
+            position of the axis is being interpolated.
             </summary>
         </member>
         <member name="T:MtconnectCore.Standard.Contracts.Enums.Streams.SpindleInterlockValues">
             <summary>
-            Available values for EVENT element <see cref="F:MtconnectCore.Standard.Contracts.Enums.Devices.DataItemTypes.EventTypes.SPINDLE_INTERLOCK"/>
+            View in the MTConnect Model browser <seealso href="https://model.mtconnect.org/#Enumeration__">model.mtconnect.org</seealso>
             </summary>
         </member>
         <member name="F:MtconnectCore.Standard.Contracts.Enums.Streams.SpindleInterlockValues.ACTIVE">
             <summary>
-            The spindle cannot be operated.
+            power has been removed and the spindle cannot be operated.
             </summary>
         </member>
         <member name="F:MtconnectCore.Standard.Contracts.Enums.Streams.SpindleInterlockValues.INACTIVE">
             <summary>
-            The spindle can be operated.
+            spindle has not been deactivated.
+            </summary>
+        </member>
+        <member name="T:MtconnectCore.Standard.Contracts.Enums.Streams.ValveStateValues">
+            <summary>
+            View in the MTConnect Model browser <seealso href="https://model.mtconnect.org/#Enumeration__">model.mtconnect.org</seealso>
+            </summary>
+        </member>
+        <member name="F:MtconnectCore.Standard.Contracts.Enums.Streams.ValveStateValues.OPEN">
+            <summary>
+            <see cref="!:ValveState">ValveState</see> where flow is allowed and the aperture is static.  > Note: For a binary value, <c>OPEN</c> indicates the valve has the maximum possible aperture.
+            </summary>
+        </member>
+        <member name="F:MtconnectCore.Standard.Contracts.Enums.Streams.ValveStateValues.OPENING">
+            <summary>
+            valve is transitioning from a <c>CLOSED</c> state to an <c>OPEN</c> state.
+            </summary>
+        </member>
+        <member name="F:MtconnectCore.Standard.Contracts.Enums.Streams.ValveStateValues.CLOSED">
+            <summary>
+            <see cref="!:ValveState">ValveState</see> where flow is not possible, the aperture is static, and the valve is completely shut.
+            </summary>
+        </member>
+        <member name="F:MtconnectCore.Standard.Contracts.Enums.Streams.ValveStateValues.CLOSING">
+            <summary>
+            valve is transitioning from an <c>OPEN</c> state to a <c>CLOSED</c> state.
             </summary>
         </member>
         <member name="T:MtconnectCore.Standard.Contracts.Enums.Streams.WaitStateValues">
             <summary>
-            Available values for EVENT element <see cref="F:MtconnectCore.Standard.Contracts.Enums.Devices.DataItemTypes.EventTypes.WAIT_STATE"/>
+            View in the MTConnect Model browser <seealso href="https://model.mtconnect.org/#Enumeration__">model.mtconnect.org</seealso>
             </summary>
         </member>
         <member name="F:MtconnectCore.Standard.Contracts.Enums.Streams.WaitStateValues.POWERING_UP">
             <summary>
-            An indication that execution is waiting while the equipment is powering up and is not currently available to begin producing parts or products.
+            execution is waiting while the equipment is powering up and is not currently available to begin producing parts or products.
             </summary>
         </member>
         <member name="F:MtconnectCore.Standard.Contracts.Enums.Streams.WaitStateValues.POWERING_DOWN">
             <summary>
-            An indication that the execution is waiting while the equipment is powering down but has not fully reached a stopped state.
+            execution is waiting while the equipment is powering down but has not fully reached a stopped state.
             </summary>
         </member>
         <member name="F:MtconnectCore.Standard.Contracts.Enums.Streams.WaitStateValues.PART_LOAD">
             <summary>
-            An indication that the execution is waiting while one or more discrete workpieces are being loaded.
+            execution is waiting while one or more discrete workpieces are being loaded.
             </summary>
         </member>
         <member name="F:MtconnectCore.Standard.Contracts.Enums.Streams.WaitStateValues.PART_UNLOAD">
             <summary>
-            An indication that the execution is waiting while one or more discrete workpieces are being unloaded.
+            execution is waiting while one or more discrete workpieces are being unloaded.
             </summary>
         </member>
         <member name="F:MtconnectCore.Standard.Contracts.Enums.Streams.WaitStateValues.TOOL_LOAD">
             <summary>
-            An indication that the execution is waiting while a tool or tooling is being loaded.
+            execution is waiting while a tool or tooling is being loaded.
             </summary>
         </member>
         <member name="F:MtconnectCore.Standard.Contracts.Enums.Streams.WaitStateValues.TOOL_UNLOAD">
             <summary>
-            An indication that the execution is waiting while a tool or tooling is being unloaded.
+            execution is waiting while a tool or tooling is being unloaded.
             </summary>
         </member>
         <member name="F:MtconnectCore.Standard.Contracts.Enums.Streams.WaitStateValues.MATERIAL_LOAD">
             <summary>
-            An indication that the execution is waiting while bulk material or the container for bulk material used in the production process is being loaded. Bulk material includes those materials from which multiple workpieces may be created.
+            execution is waiting while material is being loaded.
             </summary>
         </member>
         <member name="F:MtconnectCore.Standard.Contracts.Enums.Streams.WaitStateValues.MATERIAL_UNLOAD">
             <summary>
-            An indication that the execution is waiting while bulk material or the container for bulk material used in the production process is being unloaded. Bulk material includes those materials from which multiple workpieces may be created.
+            execution is waiting while material is being unloaded.
             </summary>
         </member>
         <member name="F:MtconnectCore.Standard.Contracts.Enums.Streams.WaitStateValues.SECONDARY_PROCESS">
             <summary>
-            An indication that the execution is waiting while another process is completed before the execution can resume.
+            execution is waiting while another process is completed before the execution can resume.
             </summary>
         </member>
         <member name="F:MtconnectCore.Standard.Contracts.Enums.Streams.WaitStateValues.PAUSING">
             <summary>
-            An indication that the execution is waiting while the equipment is pausing but the piece of equipment has not yet reached a fully paused state.
+            execution is waiting while the equipment is pausing but the piece of equipment has not yet reached a fully paused state.
             </summary>
         </member>
         <member name="F:MtconnectCore.Standard.Contracts.Enums.Streams.WaitStateValues.RESUMING">
             <summary>
-            An indication that the execution is waiting while the equipment is resuming the production cycle but has not yet resumed execution.
+            execution is waiting while the equipment is resuming the production cycle but has not yet resumed execution.
             </summary>
         </member>
         <member name="T:MtconnectCore.Standard.Contracts.Errors.MtconnectDocumentErrorException">
@@ -9704,13 +9930,6 @@
             Occurance: 0..1
             </summary>
         </member>
-        <member name="P:MtconnectCore.Standard.Documents.Streams.Condition.SubType">
-            <summary>
-            Collected from the subType attribute. Refer to Part 3 Streams - 5.8.3
-            
-            Occurance: 0..1
-            </summary>
-        </member>
         <member name="P:MtconnectCore.Standard.Documents.Streams.Condition.CompositionId">
             <summary>
             Collected from the compositionId attribute. Refer to Part 3 Streams - 5.8.3
@@ -9748,6 +9967,9 @@
             Occurance: 1
             </summary>
         </member>
+        <member name="P:MtconnectCore.Standard.Documents.Streams.DataItem.SubType">
+            <inheritdoc cref="F:MtconnectCore.Standard.Contracts.Enums.Streams.Attributes.SampleAttributes.SUB_TYPE"/>
+        </member>
         <member name="P:MtconnectCore.Standard.Documents.Streams.DataItem.Timestamp">
             <summary>
             Collected from the timestamp attribute. Refer to Part 3 Streams - 5.3.2, 5.5.2, 5.8.3
@@ -9767,15 +9989,6 @@
         </member>
         <member name="M:MtconnectCore.Standard.Documents.Streams.DataItem.#ctor(System.Xml.XmlNode,System.Xml.XmlNamespaceManager,MtconnectCore.Standard.Contracts.Enums.MtconnectVersions)">
             <inheritdoc/>
-        </member>
-        <member name="M:MtconnectCore.Standard.Documents.Streams.DataItem.tryValidateSubType``1(System.String,MtconnectCore.Standard.Contracts.Errors.MtconnectValidationException@)">
-            <summary>
-            Attempts to validate a DataItem subType value according the specified type (<typeparamref name="T"/>).
-            </summary>
-            <typeparam name="T">Reference to the <see cref="T:System.Enum"/> containing appropriate subType values.</typeparam>
-            <param name="subType">Reference to the subType provided in the Response Document.</param>
-            <param name="validationError">Output of the error found in validating the subType.</param>
-            <returns>Flag for whether or not the validation passed.</returns>
         </member>
         <member name="P:MtconnectCore.Standard.Documents.Streams.Device.Name">
             <summary>
@@ -9803,13 +10016,6 @@
         </member>
         <member name="M:MtconnectCore.Standard.Documents.Streams.Device.#ctor(System.Xml.XmlNode,System.Xml.XmlNamespaceManager,MtconnectCore.Standard.Contracts.Enums.MtconnectVersions)">
             <inheritdoc/>
-        </member>
-        <member name="P:MtconnectCore.Standard.Documents.Streams.Event.SubType">
-            <summary>
-            Collected from the subType attribute. Refer to Part 3 Streams - 5.5.2
-            
-            Occurance: 0..1
-            </summary>
         </member>
         <member name="P:MtconnectCore.Standard.Documents.Streams.Event.Name">
             <summary>
@@ -9865,13 +10071,6 @@
         </member>
         <member name="M:MtconnectCore.Standard.Documents.Streams.EventVariableDataSet.#ctor(System.Xml.XmlNode,System.Xml.XmlNamespaceManager,MtconnectCore.Standard.Contracts.Enums.MtconnectVersions)">
             <inheritdoc/>
-        </member>
-        <member name="P:MtconnectCore.Standard.Documents.Streams.Sample.SubType">
-            <summary>
-            Collected from the subType attribute. Refer to Part 3 Streams - 5.3.2
-            
-            Occurance: 0..1
-            </summary>
         </member>
         <member name="P:MtconnectCore.Standard.Documents.Streams.Sample.Name">
             <summary>

--- a/MtconnectCore/Standard/Contracts/Attributes/ObservationalValueAttribute.cs
+++ b/MtconnectCore/Standard/Contracts/Attributes/ObservationalValueAttribute.cs
@@ -1,0 +1,15 @@
+﻿using System;
+
+namespace MtconnectCore.Standard.Contracts.Attributes
+{
+    [AttributeUsage(AttributeTargets.Field, AllowMultiple = false, Inherited = false)]
+    public class ObservationalValueAttribute : Attribute
+    {
+        public Type ValueEnum { get; set; }
+
+        public ObservationalValueAttribute(Type valueEnum)
+        {
+            ValueEnum = valueEnum;
+        }
+    }
+}

--- a/MtconnectCore/Standard/Contracts/Enums/Devices/DataItemTypes/EventTypes.cs
+++ b/MtconnectCore/Standard/Contracts/Enums/Devices/DataItemTypes/EventTypes.cs
@@ -1,6 +1,7 @@
 using System;
 using System.CodeDom.Compiler;
 using MtconnectCore.Standard.Contracts.Attributes;
+using MtconnectCore.Standard.Contracts.Enums.Streams;
 
 namespace MtconnectCore.Standard.Contracts.Enums.Devices.DataItemTypes
 {
@@ -20,6 +21,7 @@ namespace MtconnectCore.Standard.Contracts.Enums.Devices.DataItemTypes
 		﻿/// {{def(EventEnum:ACTUATOR_STATE)}}
 		/// </summary>
 		[MtconnectVersionApplicability(MtconnectVersions.V_1_2_0, "https://model.mtconnect.org/")]
+		[ObservationalValue(typeof(ActuatorStateValues))]
 		ACTUATOR_STATE,
 		/// <summary>
 		﻿/// {{def(EventEnum:ALARM)}}
@@ -41,11 +43,13 @@ namespace MtconnectCore.Standard.Contracts.Enums.Devices.DataItemTypes
 		﻿/// {{def(EventEnum:AVAILABILITY)}}
 		/// </summary>
 		[MtconnectVersionApplicability(MtconnectVersions.V_1_1_0, "https://model.mtconnect.org/")]
+		[ObservationalValue(typeof(AvailabilityValues))]
 		AVAILABILITY,
 		/// <summary>
 		﻿/// {{def(EventEnum:AXIS_COUPLING)}}
 		/// </summary>
 		[MtconnectVersionApplicability(MtconnectVersions.V_1_1_0, "https://model.mtconnect.org/")]
+		[ObservationalValue(typeof(AxisCouplingValues))]
 		AXIS_COUPLING,
 		/// <summary>
 		﻿/// {{def(EventEnum:AXIS_FEEDRATE_OVERRIDE)}}
@@ -57,11 +61,13 @@ namespace MtconnectCore.Standard.Contracts.Enums.Devices.DataItemTypes
 		﻿/// {{def(EventEnum:AXIS_INTERLOCK)}}
 		/// </summary>
 		[MtconnectVersionApplicability(MtconnectVersions.V_1_3_0, "https://model.mtconnect.org/")]
+		[ObservationalValue(typeof(AxisInterlockValues))]
 		AXIS_INTERLOCK,
 		/// <summary>
 		﻿/// {{def(EventEnum:AXIS_STATE)}}
 		/// </summary>
 		[MtconnectVersionApplicability(MtconnectVersions.V_1_3_0, "https://model.mtconnect.org/")]
+		[ObservationalValue(typeof(AxisStateValues))]
 		AXIS_STATE,
 		/// <summary>
 		﻿/// {{def(EventEnum:BLOCK)}}
@@ -78,11 +84,13 @@ namespace MtconnectCore.Standard.Contracts.Enums.Devices.DataItemTypes
 		/// </summary>
 		[MtconnectVersionApplicability(MtconnectVersions.V_1_3_0, "https://model.mtconnect.org/")]
 		[ObservationalSubType(typeof(ChuckInterlockSubTypes))]
+		[ObservationalValue(typeof(ChuckInterlockValues))]
 		CHUCK_INTERLOCK,
 		/// <summary>
 		﻿/// {{def(EventEnum:CHUCK_STATE)}}
 		/// </summary>
 		[MtconnectVersionApplicability(MtconnectVersions.V_1_3_0, "https://model.mtconnect.org/")]
+		[ObservationalValue(typeof(ChuckStateValues))]
 		CHUCK_STATE,
 		/// <summary>
 		﻿/// {{def(EventEnum:CODE)}}
@@ -100,12 +108,14 @@ namespace MtconnectCore.Standard.Contracts.Enums.Devices.DataItemTypes
 		﻿/// {{def(EventEnum:CONTROLLER_MODE)}}
 		/// </summary>
 		[MtconnectVersionApplicability(MtconnectVersions.V_1_0_1, "https://model.mtconnect.org/")]
+		[ObservationalValue(typeof(ControllerModeValues))]
 		CONTROLLER_MODE,
 		/// <summary>
 		﻿/// {{def(EventEnum:CONTROLLER_MODE_OVERRIDE)}}
 		/// </summary>
 		[MtconnectVersionApplicability(MtconnectVersions.V_1_4_0, "https://model.mtconnect.org/")]
 		[ObservationalSubType(typeof(ControllerModeOverrideSubTypes))]
+		[ObservationalValue(typeof(ControllerModeOverrideValues))]
 		CONTROLLER_MODE_OVERRIDE,
 		/// <summary>
 		﻿/// {{def(EventEnum:COUPLED_AXES)}}
@@ -128,38 +138,45 @@ namespace MtconnectCore.Standard.Contracts.Enums.Devices.DataItemTypes
 		/// </summary>
 		[MtconnectVersionApplicability(MtconnectVersions.V_1_0_1, "https://model.mtconnect.org/")]
 		[ObservationalSubType(typeof(DirectionSubTypes))]
+		[ObservationalValue(typeof(DirectionValues))]
 		DIRECTION,
 		/// <summary>
 		﻿/// {{def(EventEnum:DOOR_STATE)}}
 		/// </summary>
 		[MtconnectVersionApplicability(MtconnectVersions.V_1_1_0, "https://model.mtconnect.org/")]
+		[ObservationalValue(typeof(DoorStateValues))]
 		DOOR_STATE,
 		/// <summary>
 		﻿/// {{def(EventEnum:EMERGENCY_STOP)}}
 		/// </summary>
 		[MtconnectVersionApplicability(MtconnectVersions.V_1_1_0, "https://model.mtconnect.org/")]
+		[ObservationalValue(typeof(EmergencyStopValues))]
 		EMERGENCY_STOP,
 		/// <summary>
 		﻿/// {{def(EventEnum:END_OF_BAR)}}
 		/// </summary>
 		[MtconnectVersionApplicability(MtconnectVersions.V_1_3_0, "https://model.mtconnect.org/")]
 		[ObservationalSubType(typeof(EndOfBarSubTypes))]
+		[ObservationalValue(typeof(EndOfBarValues))]
 		END_OF_BAR,
 		/// <summary>
 		﻿/// {{def(EventEnum:EQUIPMENT_MODE)}}
 		/// </summary>
 		[MtconnectVersionApplicability(MtconnectVersions.V_1_4_0, "https://model.mtconnect.org/")]
 		[ObservationalSubType(typeof(EquipmentModeSubTypes))]
+		[ObservationalValue(typeof(EquipmentModeValues))]
 		EQUIPMENT_MODE,
 		/// <summary>
 		﻿/// {{def(EventEnum:EXECUTION)}}
 		/// </summary>
 		[MtconnectVersionApplicability(MtconnectVersions.V_1_0_1, "https://model.mtconnect.org/")]
+		[ObservationalValue(typeof(ExecutionValues))]
 		EXECUTION,
 		/// <summary>
 		﻿/// {{def(EventEnum:FUNCTIONAL_MODE)}}
 		/// </summary>
 		[MtconnectVersionApplicability(MtconnectVersions.V_1_3_0, "https://model.mtconnect.org/")]
+		[ObservationalValue(typeof(FunctionalModeValues))]
 		FUNCTIONAL_MODE,
 		/// <summary>
 		﻿/// {{def(EventEnum:HARDNESS)}}
@@ -221,6 +238,7 @@ namespace MtconnectCore.Standard.Contracts.Enums.Devices.DataItemTypes
 		﻿/// {{def(EventEnum:PART_DETECT)}}
 		/// </summary>
 		[MtconnectVersionApplicability(MtconnectVersions.V_1_5_0, "https://model.mtconnect.org/")]
+		[ObservationalValue(typeof(PartDetectValues))]
 		PART_DETECT,
 		/// <summary>
 		﻿/// {{def(EventEnum:PART_ID)}}
@@ -243,18 +261,21 @@ namespace MtconnectCore.Standard.Contracts.Enums.Devices.DataItemTypes
 		﻿/// {{def(EventEnum:PATH_MODE)}}
 		/// </summary>
 		[MtconnectVersionApplicability(MtconnectVersions.V_1_1_0, "https://model.mtconnect.org/")]
+		[ObservationalValue(typeof(PathModeValues))]
 		PATH_MODE,
 		/// <summary>
 		﻿/// {{def(EventEnum:POWER_STATE)}}
 		/// </summary>
 		[MtconnectVersionApplicability(MtconnectVersions.V_1_1_0, "https://model.mtconnect.org/")]
 		[ObservationalSubType(typeof(PowerStateSubTypes))]
+		[ObservationalValue(typeof(PowerStateValues))]
 		POWER_STATE,
 		/// <summary>
 		﻿/// {{def(EventEnum:POWER_STATUS)}}
 		/// </summary>
 		[Obsolete("Deprecated according to https://model.mtconnect.org/")]
 		[MtconnectVersionApplicability(MtconnectVersions.V_1_0_1, "https://model.mtconnect.org/", MtconnectVersions.V_1_1_0)]
+		[ObservationalValue(typeof(PowerStatusValues))]
 		POWER_STATUS,
 		/// <summary>
 		﻿/// {{def(EventEnum:PROCESS_TIME)}}
@@ -278,6 +299,7 @@ namespace MtconnectCore.Standard.Contracts.Enums.Devices.DataItemTypes
 		﻿/// {{def(EventEnum:PROGRAM_EDIT)}}
 		/// </summary>
 		[MtconnectVersionApplicability(MtconnectVersions.V_1_3_0, "https://model.mtconnect.org/")]
+		[ObservationalValue(typeof(ProgramEditValues))]
 		PROGRAM_EDIT,
 		/// <summary>
 		﻿/// {{def(EventEnum:PROGRAM_EDIT_NAME)}}
@@ -301,6 +323,7 @@ namespace MtconnectCore.Standard.Contracts.Enums.Devices.DataItemTypes
 		/// </summary>
 		[MtconnectVersionApplicability(MtconnectVersions.V_1_5_0, "https://model.mtconnect.org/")]
 		[ObservationalSubType(typeof(ProgramLocationTypeSubTypes))]
+		[ObservationalValue(typeof(ProgramLocationTypeValues))]
 		PROGRAM_LOCATION_TYPE,
 		/// <summary>
 		﻿/// {{def(EventEnum:PROGRAM_NEST_LEVEL)}}  If an initial value is not defined, the nesting level associated with the highest or initial nesting level of the program <b>MUST</b> default to zero (0). 
@@ -311,6 +334,7 @@ namespace MtconnectCore.Standard.Contracts.Enums.Devices.DataItemTypes
 		﻿/// {{def(EventEnum:ROTARY_MODE)}}
 		/// </summary>
 		[MtconnectVersionApplicability(MtconnectVersions.V_1_1_0, "https://model.mtconnect.org/")]
+		[ObservationalValue(typeof(RotaryModeValues))]
 		ROTARY_MODE,
 		/// <summary>
 		﻿/// {{def(EventEnum:ROTARY_VELOCITY_OVERRIDE)}}  This command represents a percentage change to the velocity calculated by a logic or motion program or set by a switch for a <see cref="Rotary">Rotary</see> type axis.
@@ -326,6 +350,7 @@ namespace MtconnectCore.Standard.Contracts.Enums.Devices.DataItemTypes
 		﻿/// {{def(EventEnum:SPINDLE_INTERLOCK)}}
 		/// </summary>
 		[MtconnectVersionApplicability(MtconnectVersions.V_1_3_0, "https://model.mtconnect.org/")]
+		[ObservationalValue(typeof(SpindleInterlockValues))]
 		SPINDLE_INTERLOCK,
 		/// <summary>
 		﻿/// {{def(EventEnum:TOOL_ASSET_ID)}}
@@ -369,6 +394,7 @@ namespace MtconnectCore.Standard.Contracts.Enums.Devices.DataItemTypes
 		﻿/// {{def(EventEnum:WAIT_STATE)}}
 		/// </summary>
 		[MtconnectVersionApplicability(MtconnectVersions.V_1_5_0, "https://model.mtconnect.org/")]
+		[ObservationalValue(typeof(WaitStateValues))]
 		WAIT_STATE,
 		/// <summary>
 		﻿/// {{def(EventEnum:WIRE)}}
@@ -441,6 +467,7 @@ namespace MtconnectCore.Standard.Contracts.Enums.Devices.DataItemTypes
 		﻿/// {{def(EventEnum:PART_STATUS)}}  If unique identifier is given, part status is for that individual. If group identifier is given without a unique identifier, then the status is assumed to be for the whole group.
 		/// </summary>
 		[MtconnectVersionApplicability(MtconnectVersions.V_1_7_0, "https://model.mtconnect.org/")]
+		[ObservationalValue(typeof(PartStatusValues))]
 		PART_STATUS,
 		/// <summary>
 		﻿/// {{def(EventEnum:ALARM_LIMIT)}}
@@ -483,6 +510,7 @@ namespace MtconnectCore.Standard.Contracts.Enums.Devices.DataItemTypes
 		﻿/// {{def(EventEnum:CONNECTION_STATUS)}}
 		/// </summary>
 		[MtconnectVersionApplicability(MtconnectVersions.V_1_7_0, "https://model.mtconnect.org/")]
+		[ObservationalValue(typeof(ConnectionStatusValues))]
 		CONNECTION_STATUS,
 		/// <summary>
 		﻿/// {{def(EventEnum:ADAPTER_SOFTWARE_VERSION)}}
@@ -555,22 +583,26 @@ namespace MtconnectCore.Standard.Contracts.Enums.Devices.DataItemTypes
 		﻿/// {{def(EventEnum:PART_PROCESSING_STATE)}}
 		/// </summary>
 		[MtconnectVersionApplicability(MtconnectVersions.V_1_8_0, "https://model.mtconnect.org/")]
+		[ObservationalValue(typeof(PartProcessingStateValues))]
 		PART_PROCESSING_STATE,
 		/// <summary>
 		﻿/// {{def(EventEnum:PROCESS_STATE)}}
 		/// </summary>
 		[MtconnectVersionApplicability(MtconnectVersions.V_1_8_0, "https://model.mtconnect.org/")]
+		[ObservationalValue(typeof(ProcessStateValues))]
 		PROCESS_STATE,
 		/// <summary>
 		﻿/// {{def(EventEnum:VALVE_STATE)}}
 		/// </summary>
 		[MtconnectVersionApplicability(MtconnectVersions.V_1_8_0, "https://model.mtconnect.org/")]
 		[ObservationalSubType(typeof(ValveStateSubTypes))]
+		[ObservationalValue(typeof(ValveStateValues))]
 		VALVE_STATE,
 		/// <summary>
 		﻿/// {{def(EventEnum:LOCK_STATE)}}
 		/// </summary>
 		[MtconnectVersionApplicability(MtconnectVersions.V_1_8_0, "https://model.mtconnect.org/")]
+		[ObservationalValue(typeof(LockStateValues))]
 		LOCK_STATE,
 		/// <summary>
 		﻿/// {{def(EventEnum:UNLOAD_COUNT)}}
@@ -588,6 +620,7 @@ namespace MtconnectCore.Standard.Contracts.Enums.Devices.DataItemTypes
 		﻿/// {{def(EventEnum:OPERATING_MODE)}}
 		/// </summary>
 		[MtconnectVersionApplicability(MtconnectVersions.V_2_0_0, "https://model.mtconnect.org/")]
+		[ObservationalValue(typeof(OperatingModeValues))]
 		OPERATING_MODE,
 		/// <summary>
 		﻿/// {{def(EventEnum:ASSET_COUNT)}}
@@ -608,6 +641,7 @@ namespace MtconnectCore.Standard.Contracts.Enums.Devices.DataItemTypes
 		﻿/// {{def(EventEnum:PART_COUNT_TYPE)}}
 		/// </summary>
 		[MtconnectVersionApplicability(MtconnectVersions.V_2_0_0, "https://model.mtconnect.org/")]
+		[ObservationalValue(typeof(PartCountTypeValues))]
 		PART_COUNT_TYPE,
 		/// <summary>
 		﻿/// {{def(EventEnum:CLOCK_TIME)}}
@@ -628,11 +662,13 @@ namespace MtconnectCore.Standard.Contracts.Enums.Devices.DataItemTypes
 		﻿/// {{def(EventEnum:LEAK_DETECT)}}
 		/// </summary>
 		[MtconnectVersionApplicability(MtconnectVersions.V_2_1_0, "https://model.mtconnect.org/")]
+		[ObservationalValue(typeof(LeakDetectValues))]
 		LEAK_DETECT,
 		/// <summary>
 		﻿/// {{def(EventEnum:BATTERY_STATE)}}
 		/// </summary>
 		[MtconnectVersionApplicability(MtconnectVersions.V_2_1_0, "https://model.mtconnect.org/")]
+		[ObservationalValue(typeof(BatteryStateValues))]
 		BATTERY_STATE,
 	}
 }

--- a/MtconnectCore/Standard/Contracts/Enums/Streams/AvailabilityValues.cs
+++ b/MtconnectCore/Standard/Contracts/Enums/Streams/AvailabilityValues.cs
@@ -1,22 +1,25 @@
-﻿using MtconnectCore.Standard.Contracts.Attributes;
-using MtconnectCore.Standard.Contracts.Enums.Devices.DataItemTypes;
+using System;
+using System.CodeDom.Compiler;
+using MtconnectCore.Standard.Contracts.Attributes;
 
 namespace MtconnectCore.Standard.Contracts.Enums.Streams
 {
-    /// <summary>
-    /// Available values for EVENT element <see cref="EventTypes.AVAILABILITY"/>
-    /// </summary>
-    [MtconnectVersionApplicability(MtconnectVersions.V_1_1_0, "Part 3 Section 3.10")]
-    public enum AvailabilityValues {
-        /// <summary>
-        /// The component is available.
-        /// </summary>
-        [MtconnectVersionApplicability(MtconnectVersions.V_1_1_0, "Part 3 Section 3.10")]
-        AVAILABLE,
-        /// <summary>
-        /// The component is not available.
-        /// </summary>
-        [MtconnectVersionApplicability(MtconnectVersions.V_1_1_0, "Part 3 Section 3.10")]
-        UNAVAILABLE
-    }
+	/// <summary>
+	/// View in the MTConnect Model browser <seealso href="https://model.mtconnect.org/#Enumeration__">model.mtconnect.org</seealso>
+	﻿	/// </summary>
+	[MtconnectVersionApplicability(MtconnectVersions.V_1_1_0, "https://model.mtconnect.org/")]
+	[GeneratedCode("MtconnectTranspiler.Sinks.MtconnectCore", "0.0.12.0")]
+	public enum AvailabilityValues
+	{
+		/// <summary>
+		﻿/// data source is active and capable of providing data.
+		/// </summary>
+		[MtconnectVersionApplicability(MtconnectVersions.V_1_1_0, "https://model.mtconnect.org/")]
+		AVAILABLE,
+		/// <summary>
+		﻿/// data source is either inactive or not capable of providing data.
+		/// </summary>
+		[MtconnectVersionApplicability(MtconnectVersions.V_1_1_0, "https://model.mtconnect.org/")]
+		UNAVAILABLE,
+	}
 }

--- a/MtconnectCore/Standard/Contracts/Enums/Streams/AxisCouplingValues.cs
+++ b/MtconnectCore/Standard/Contracts/Enums/Streams/AxisCouplingValues.cs
@@ -1,33 +1,35 @@
-﻿using MtconnectCore.Standard.Contracts.Attributes;
-using MtconnectCore.Standard.Contracts.Enums.Devices.DataItemTypes;
+using System;
+using System.CodeDom.Compiler;
+using MtconnectCore.Standard.Contracts.Attributes;
 
 namespace MtconnectCore.Standard.Contracts.Enums.Streams
 {
-    /// <summary>
-    /// Available values for EVENT element <see cref="EventTypes.AXIS_COUPLING"/>
-    /// </summary>
-    [MtconnectVersionApplicability(MtconnectVersions.V_1_1_0, "Part 3 Section 3.10.1")]
-    public enum AxisCouplingValues
-    {
-        /// <summary>
-        /// The axes are physically connected to each other and must  operate as a single unit.
-        /// </summary>
-        [MtconnectVersionApplicability(MtconnectVersions.V_1_1_0, "Part 3 Section 3.10.1")]
-        TANDEM,
-        /// <summary>
-        /// The axes are coupled and are operating together in  lockstep.
-        /// </summary>
-        [MtconnectVersionApplicability(MtconnectVersions.V_1_1_0, "Part 3 Section 3.10.1")]
-        SYNCHRONOUS,
-        /// <summary>
-        /// The axis is the master of the CoupledAxes
-        /// </summary>
-        [MtconnectVersionApplicability(MtconnectVersions.V_1_1_0, "Part 3 Section 3.10.1")]
-        MASTER,
-        /// <summary>
-        /// The axis is a slave of the CoupledAxes
-        /// </summary>
-        [MtconnectVersionApplicability(MtconnectVersions.V_1_1_0, "Part 3 Section 3.10.1")]
-        SLAVE
-    }
+	/// <summary>
+	/// View in the MTConnect Model browser <seealso href="https://model.mtconnect.org/#Enumeration__">model.mtconnect.org</seealso>
+	﻿	/// </summary>
+	[MtconnectVersionApplicability(MtconnectVersions.V_1_1_0, "https://model.mtconnect.org/")]
+	[GeneratedCode("MtconnectTranspiler.Sinks.MtconnectCore", "0.0.12.0")]
+	public enum AxisCouplingValues
+	{
+		/// <summary>
+		﻿/// axes are physically connected to each other and operate as a single unit.
+		/// </summary>
+		[MtconnectVersionApplicability(MtconnectVersions.V_1_1_0, "https://model.mtconnect.org/")]
+		TANDEM,
+		/// <summary>
+		﻿/// axes are not physically connected to each other but are operating together in lockstep.
+		/// </summary>
+		[MtconnectVersionApplicability(MtconnectVersions.V_1_1_0, "https://model.mtconnect.org/")]
+		SYNCHRONOUS,
+		/// <summary>
+		﻿/// axis is the master of the <see cref="CoupledAxes">CoupledAxes</see>.
+		/// </summary>
+		[MtconnectVersionApplicability(MtconnectVersions.V_1_1_0, "https://model.mtconnect.org/")]
+		MASTER,
+		/// <summary>
+		﻿/// axis is a slave to the <see cref="CoupledAxes">CoupledAxes</see>.
+		/// </summary>
+		[MtconnectVersionApplicability(MtconnectVersions.V_1_1_0, "https://model.mtconnect.org/")]
+		SLAVE,
+	}
 }

--- a/MtconnectCore/Standard/Contracts/Enums/Streams/AxisInterlockValues.cs
+++ b/MtconnectCore/Standard/Contracts/Enums/Streams/AxisInterlockValues.cs
@@ -1,23 +1,25 @@
-﻿using MtconnectCore.Standard.Contracts.Attributes;
-using MtconnectCore.Standard.Contracts.Enums.Devices.DataItemTypes;
+using System;
+using System.CodeDom.Compiler;
+using MtconnectCore.Standard.Contracts.Attributes;
 
 namespace MtconnectCore.Standard.Contracts.Enums.Streams
 {
-    /// <summary>
-    /// Available values for EVENT element <see cref="EventTypes.AXIS_INTERLOCK"/>
-    /// </summary>
-    [MtconnectVersionApplicability(MtconnectVersions.V_1_4_0, "Part 3 Section 6.2")]
-    public enum AxisInterlockValues
-    {
-        /// <summary>
-        /// The axis lockout function is activated power has been removed from the axis, and the axis is allowed to move freely.
-        /// </summary>
-        [MtconnectVersionApplicability(MtconnectVersions.V_1_4_0, "Part 3 Section 6.2")]
-        ACTIVE,
-        /// <summary>
-        /// The axis lockout function has not  been activated, the axis may be powered, and the axis is capable of being controlled by another component.
-        /// </summary>
-        [MtconnectVersionApplicability(MtconnectVersions.V_1_4_0, "Part 3 Section 6.2")]
-        INACTIVE
-    }
+	/// <summary>
+	/// View in the MTConnect Model browser <seealso href="https://model.mtconnect.org/#Enumeration__">model.mtconnect.org</seealso>
+	﻿	/// </summary>
+	[MtconnectVersionApplicability(MtconnectVersions.V_1_3_0, "https://model.mtconnect.org/")]
+	[GeneratedCode("MtconnectTranspiler.Sinks.MtconnectCore", "0.0.12.0")]
+	public enum AxisInterlockValues
+	{
+		/// <summary>
+		﻿/// axis lockout function is activated, power has been removed from the axis, and the axis is allowed to move freely.
+		/// </summary>
+		[MtconnectVersionApplicability(MtconnectVersions.V_1_3_0, "https://model.mtconnect.org/")]
+		ACTIVE,
+		/// <summary>
+		﻿/// axis lockout function has not been activated, the axis may be powered, and the axis is capable of being controlled by another component.
+		/// </summary>
+		[MtconnectVersionApplicability(MtconnectVersions.V_1_3_0, "https://model.mtconnect.org/")]
+		INACTIVE,
+	}
 }

--- a/MtconnectCore/Standard/Contracts/Enums/Streams/AxisStateValues.cs
+++ b/MtconnectCore/Standard/Contracts/Enums/Streams/AxisStateValues.cs
@@ -1,33 +1,35 @@
-﻿using MtconnectCore.Standard.Contracts.Attributes;
-using MtconnectCore.Standard.Contracts.Enums.Devices.DataItemTypes;
+using System;
+using System.CodeDom.Compiler;
+using MtconnectCore.Standard.Contracts.Attributes;
 
 namespace MtconnectCore.Standard.Contracts.Enums.Streams
 {
-    /// <summary>
-    /// Available values for EVENT element <see cref="EventTypes.AXIS_STATE"/>
-    /// </summary>
-    [MtconnectVersionApplicability(MtconnectVersions.V_1_3_0, "Part 3 Section 3.10.3")]
-    public enum AxisStateValues
-    {
-        /// <summary>
-        /// The axis is in its home position.
-        /// </summary>
-        [MtconnectVersionApplicability(MtconnectVersions.V_1_3_0, "Part 3 Section 3.10.3")]
-        HOME,
-        /// <summary>
-        /// The axis is in motion
-        /// </summary>
-        [MtconnectVersionApplicability(MtconnectVersions.V_1_3_0, "Part 3 Section 3.10.3")]
-        TRAVEL,
-        /// <summary>
-        /// The axis has been moved to a fixed  position and is being maintained in that position either electrically or mechanically. Action is required to release the axis from this position.
-        /// </summary>
-        [MtconnectVersionApplicability(MtconnectVersions.V_1_4_0, "Part 3 Section 6.2")]
-        PARKED,
-        /// <summary>
-        /// The axis is stopped
-        /// </summary>
-        [MtconnectVersionApplicability(MtconnectVersions.V_1_3_0, "Part 3 Section 3.10.3")]
-        STOPPED
-    }
+	/// <summary>
+	/// View in the MTConnect Model browser <seealso href="https://model.mtconnect.org/#Enumeration__">model.mtconnect.org</seealso>
+	﻿	/// </summary>
+	[MtconnectVersionApplicability(MtconnectVersions.V_1_3_0, "https://model.mtconnect.org/")]
+	[GeneratedCode("MtconnectTranspiler.Sinks.MtconnectCore", "0.0.12.0")]
+	public enum AxisStateValues
+	{
+		/// <summary>
+		﻿/// axis is in its home position.
+		/// </summary>
+		[MtconnectVersionApplicability(MtconnectVersions.V_1_3_0, "https://model.mtconnect.org/")]
+		HOME,
+		/// <summary>
+		﻿/// axis is in motion.
+		/// </summary>
+		[MtconnectVersionApplicability(MtconnectVersions.V_1_3_0, "https://model.mtconnect.org/")]
+		TRAVEL,
+		/// <summary>
+		﻿/// axis has been moved to a fixed position and is being maintained in that position either electrically or mechanically.   Action is required to release the axis from this position.
+		/// </summary>
+		[MtconnectVersionApplicability(MtconnectVersions.V_1_3_0, "https://model.mtconnect.org/")]
+		PARKED,
+		/// <summary>
+		﻿/// axis is stopped.
+		/// </summary>
+		[MtconnectVersionApplicability(MtconnectVersions.V_1_3_0, "https://model.mtconnect.org/")]
+		STOPPED,
+	}
 }

--- a/MtconnectCore/Standard/Contracts/Enums/Streams/BatteryStateValues.cs
+++ b/MtconnectCore/Standard/Contracts/Enums/Streams/BatteryStateValues.cs
@@ -1,0 +1,35 @@
+using System;
+using System.CodeDom.Compiler;
+using MtconnectCore.Standard.Contracts.Attributes;
+
+namespace MtconnectCore.Standard.Contracts.Enums.Streams
+{
+	/// <summary>
+	/// View in the MTConnect Model browser <seealso href="https://model.mtconnect.org/#Enumeration__">model.mtconnect.org</seealso>
+	﻿	/// </summary>
+	[MtconnectVersionApplicability(MtconnectVersions.V_2_1_0, "https://model.mtconnect.org/")]
+	[GeneratedCode("MtconnectTranspiler.Sinks.MtconnectCore", "0.0.12.0")]
+	public enum BatteryStateValues
+	{
+		/// <summary>
+		﻿/// <see cref="Component">Component</see> is at it's maximum rated charge level.
+		/// </summary>
+		[MtconnectVersionApplicability(MtconnectVersions.V_2_1_0, "https://model.mtconnect.org/")]
+		CHARGED,
+		/// <summary>
+		﻿/// <see cref="Component">Component</see>'s charge is increasing.
+		/// </summary>
+		[MtconnectVersionApplicability(MtconnectVersions.V_2_1_0, "https://model.mtconnect.org/")]
+		CHARGING,
+		/// <summary>
+		﻿/// <see cref="Component">Component</see>'s charge is decreasing.
+		/// </summary>
+		[MtconnectVersionApplicability(MtconnectVersions.V_2_1_0, "https://model.mtconnect.org/")]
+		DISCHARGING,
+		/// <summary>
+		﻿/// <see cref="Component">Component</see> is at it's minimum charge level.
+		/// </summary>
+		[MtconnectVersionApplicability(MtconnectVersions.V_2_1_0, "https://model.mtconnect.org/")]
+		DISCHARGED,
+	}
+}

--- a/MtconnectCore/Standard/Contracts/Enums/Streams/ChuckInterlockValues.cs
+++ b/MtconnectCore/Standard/Contracts/Enums/Streams/ChuckInterlockValues.cs
@@ -1,23 +1,25 @@
-﻿using MtconnectCore.Standard.Contracts.Attributes;
-using MtconnectCore.Standard.Contracts.Enums.Devices.DataItemTypes;
+using System;
+using System.CodeDom.Compiler;
+using MtconnectCore.Standard.Contracts.Attributes;
 
 namespace MtconnectCore.Standard.Contracts.Enums.Streams
 {
-    /// <summary>
-    /// Available values for EVENT element <see cref="EventTypes.CHUCK_INTERLOCK"/>
-    /// </summary>
-    [MtconnectVersionApplicability(MtconnectVersions.V_1_3_0, "Part 3 Section 3.10.3")]
-    public enum ChuckInterlockValues
-    {
-        /// <summary>
-        /// The chuck cannot be operated.
-        /// </summary>
-        [MtconnectVersionApplicability(MtconnectVersions.V_1_3_0, "Part 3 Section 3.10.3")]
-        ACTIVE,
-        /// <summary>
-        /// The chuck can be operated.
-        /// </summary>
-        [MtconnectVersionApplicability(MtconnectVersions.V_1_3_0, "Part 3 Section 3.10.3")]
-        INACTIVE,
-    }
+	/// <summary>
+	/// View in the MTConnect Model browser <seealso href="https://model.mtconnect.org/#Enumeration__">model.mtconnect.org</seealso>
+	﻿	/// </summary>
+	[MtconnectVersionApplicability(MtconnectVersions.V_1_3_0, "https://model.mtconnect.org/")]
+	[GeneratedCode("MtconnectTranspiler.Sinks.MtconnectCore", "0.0.12.0")]
+	public enum ChuckInterlockValues
+	{
+		/// <summary>
+		﻿/// chuck cannot be unclamped.
+		/// </summary>
+		[MtconnectVersionApplicability(MtconnectVersions.V_1_3_0, "https://model.mtconnect.org/")]
+		ACTIVE,
+		/// <summary>
+		﻿/// chuck can be unclamped.
+		/// </summary>
+		[MtconnectVersionApplicability(MtconnectVersions.V_1_3_0, "https://model.mtconnect.org/")]
+		INACTIVE,
+	}
 }

--- a/MtconnectCore/Standard/Contracts/Enums/Streams/ChuckStateValues.cs
+++ b/MtconnectCore/Standard/Contracts/Enums/Streams/ChuckStateValues.cs
@@ -1,28 +1,30 @@
-﻿using MtconnectCore.Standard.Contracts.Attributes;
-using MtconnectCore.Standard.Contracts.Enums.Devices.DataItemTypes;
+using System;
+using System.CodeDom.Compiler;
+using MtconnectCore.Standard.Contracts.Attributes;
 
 namespace MtconnectCore.Standard.Contracts.Enums.Streams
 {
-    /// <summary>
-    /// Available values for EVENT element <see cref="EventTypes.CHUCK_STATE"/>
-    /// </summary>
-    [MtconnectVersionApplicability(MtconnectVersions.V_1_3_0, "Part 3 Section 3.10.3")]
-    public enum ChuckStateValues
-    {
-        /// <summary>
-        /// The chuck is open to the point of a positive confirmation
-        /// </summary>
-        [MtconnectVersionApplicability(MtconnectVersions.V_1_3_0, "Part 3 Section 3.10.3")]
-        OPEN,
-        /// <summary>
-        /// The chuck is closed to the point of a positive  confirmation
-        /// </summary>
-        [MtconnectVersionApplicability(MtconnectVersions.V_1_3_0, "Part 3 Section 3.10.3")]
-        CLOSED,
-        /// <summary>
-        /// The chuck is not closed to the point of a positive  confirmation and not open to the point of a positive confirmation
-        /// </summary>
-        [MtconnectVersionApplicability(MtconnectVersions.V_1_3_0, "Part 3 Section 3.10.3")]
-        UNLATCHED
-    }
+	/// <summary>
+	/// View in the MTConnect Model browser <seealso href="https://model.mtconnect.org/#Enumeration__">model.mtconnect.org</seealso>
+	﻿	/// </summary>
+	[MtconnectVersionApplicability(MtconnectVersions.V_1_3_0, "https://model.mtconnect.org/")]
+	[GeneratedCode("MtconnectTranspiler.Sinks.MtconnectCore", "0.0.12.0")]
+	public enum ChuckStateValues
+	{
+		/// <summary>
+		﻿/// <see cref="Chuck">Chuck</see> is open to the point of a positive confirmation.
+		/// </summary>
+		[MtconnectVersionApplicability(MtconnectVersions.V_1_3_0, "https://model.mtconnect.org/")]
+		OPEN,
+		/// <summary>
+		﻿/// <see cref="Chuck">Chuck</see> is closed to the point of a positive confirmation.
+		/// </summary>
+		[MtconnectVersionApplicability(MtconnectVersions.V_1_3_0, "https://model.mtconnect.org/")]
+		CLOSED,
+		/// <summary>
+		﻿/// <see cref="Chuck">Chuck</see> is not closed to the point of a positive confirmation and not open to the point of a positive confirmation.   It is in an intermediate position.
+		/// </summary>
+		[MtconnectVersionApplicability(MtconnectVersions.V_1_3_0, "https://model.mtconnect.org/")]
+		UNLATCHED,
+	}
 }

--- a/MtconnectCore/Standard/Contracts/Enums/Streams/ConnectionStatusValues.cs
+++ b/MtconnectCore/Standard/Contracts/Enums/Streams/ConnectionStatusValues.cs
@@ -1,28 +1,30 @@
-﻿using MtconnectCore.Standard.Contracts.Attributes;
-using MtconnectCore.Standard.Contracts.Enums.Devices.DataItemTypes;
+using System;
+using System.CodeDom.Compiler;
+using MtconnectCore.Standard.Contracts.Attributes;
 
 namespace MtconnectCore.Standard.Contracts.Enums.Streams
 {
-    /// <summary>
-    /// Available values for EVENT element <see cref="EventTypes.CONNECTION_STATUS"/>
-    /// </summary>
-    [MtconnectVersionApplicability(MtconnectVersions.V_1_7_0, "Part 3 Section 6.2")]
-    public enum ConnectionStatusValues
-    {
-        /// <summary>
-        /// Represents no connection at all.
-        /// </summary>
-        [MtconnectVersionApplicability(MtconnectVersions.V_1_7_0, "Part 3 Section 6.2")]
-        CLOSED,
-        /// <summary>
-        /// Represents the Agent waiting for a connection request from an Adapter.
-        /// </summary>
-        [MtconnectVersionApplicability(MtconnectVersions.V_1_7_0, "Part 3 Section 6.2")]
-        LISTEN,
-        /// <summary>
-        /// Represents an open connection. The normal state for the data transfer phase of the connection.
-        /// </summary>
-        [MtconnectVersionApplicability(MtconnectVersions.V_1_7_0, "Part 3 Section 6.2")]
-        ESTABLISHED
-    }
+	/// <summary>
+	/// View in the MTConnect Model browser <seealso href="https://model.mtconnect.org/#Enumeration__">model.mtconnect.org</seealso>
+	﻿	/// </summary>
+	[MtconnectVersionApplicability(MtconnectVersions.V_1_7_0, "https://model.mtconnect.org/")]
+	[GeneratedCode("MtconnectTranspiler.Sinks.MtconnectCore", "0.0.12.0")]
+	public enum ConnectionStatusValues
+	{
+		/// <summary>
+		﻿/// no connection at all.
+		/// </summary>
+		[MtconnectVersionApplicability(MtconnectVersions.V_1_7_0, "https://model.mtconnect.org/")]
+		CLOSED,
+		/// <summary>
+		﻿/// <i>agent</i> is waiting for a connection request from an <i>adapter</i>.
+		/// </summary>
+		[MtconnectVersionApplicability(MtconnectVersions.V_1_7_0, "https://model.mtconnect.org/")]
+		LISTEN,
+		/// <summary>
+		﻿/// open connection.  The normal state for the data transfer phase of the connection.
+		/// </summary>
+		[MtconnectVersionApplicability(MtconnectVersions.V_1_7_0, "https://model.mtconnect.org/")]
+		ESTABLISHED,
+	}
 }

--- a/MtconnectCore/Standard/Contracts/Enums/Streams/ControllerModeOverrideValues.cs
+++ b/MtconnectCore/Standard/Contracts/Enums/Streams/ControllerModeOverrideValues.cs
@@ -1,23 +1,25 @@
-﻿using MtconnectCore.Standard.Contracts.Attributes;
-using MtconnectCore.Standard.Contracts.Enums.Devices.DataItemTypes;
+using System;
+using System.CodeDom.Compiler;
+using MtconnectCore.Standard.Contracts.Attributes;
 
 namespace MtconnectCore.Standard.Contracts.Enums.Streams
 {
-    /// <summary>
-    /// Available values for EVENT element <see cref="EventTypes.CONTROLLER_MODE_OVERRIDE"/>
-    /// </summary>
-    [MtconnectVersionApplicability(MtconnectVersions.V_1_4_0, "Part 3 Section 6.2")]
-    public enum ControllerModeOverrideValues
-    {
-        /// <summary>
-        /// The indicator of the  ControllerModeOverride is in the ON state and the mode override is active.
-        /// </summary>
-        [MtconnectVersionApplicability(MtconnectVersions.V_1_4_0, "Part 3 Section 6.2")]
-        ON,
-        /// <summary>
-        /// The indicator of the  ControllerModeOverride is in the OFF state and the mode override is inactive
-        /// </summary>
-        [MtconnectVersionApplicability(MtconnectVersions.V_1_4_0, "Part 3 Section 6.2")]
-        OFF
-    }
+	/// <summary>
+	/// View in the MTConnect Model browser <seealso href="https://model.mtconnect.org/#Enumeration__">model.mtconnect.org</seealso>
+	﻿	/// </summary>
+	[MtconnectVersionApplicability(MtconnectVersions.V_1_4_0, "https://model.mtconnect.org/")]
+	[GeneratedCode("MtconnectTranspiler.Sinks.MtconnectCore", "0.0.12.0")]
+	public enum ControllerModeOverrideValues
+	{
+		/// <summary>
+		﻿/// <see cref="ControllerModeOverride">ControllerModeOverride</see> is in the <c>ON</c> state and the mode override is active.
+		/// </summary>
+		[MtconnectVersionApplicability(MtconnectVersions.V_1_4_0, "https://model.mtconnect.org/")]
+		ON,
+		/// <summary>
+		﻿/// <see cref="ControllerModeOverride">ControllerModeOverride</see> is in the <c>OFF</c> state and the mode override is inactive.
+		/// </summary>
+		[MtconnectVersionApplicability(MtconnectVersions.V_1_4_0, "https://model.mtconnect.org/")]
+		OFF,
+	}
 }

--- a/MtconnectCore/Standard/Contracts/Enums/Streams/ControllerModeValues.cs
+++ b/MtconnectCore/Standard/Contracts/Enums/Streams/ControllerModeValues.cs
@@ -1,50 +1,46 @@
-﻿using MtconnectCore.Standard.Contracts.Attributes;
-using MtconnectCore.Standard.Contracts.Enums.Devices.DataItemTypes;
 using System;
+using System.CodeDom.Compiler;
+using MtconnectCore.Standard.Contracts.Attributes;
 
 namespace MtconnectCore.Standard.Contracts.Enums.Streams
 {
-    /// <summary>
-    /// Available values for EVENT element <see cref="EventTypes.CONTROLLER_MODE"/>
-    /// </summary>
-    [MtconnectVersionApplicability(MtconnectVersions.V_1_0_1, "Part 3 Section 3.8.1")]
-    public enum ControllerModeValues {
-        /// <summary>
-        /// The controller is configured to automatically execute a  program.
-        /// </summary>
-        [MtconnectVersionApplicability(MtconnectVersions.V_1_0_1, "Part 3 Section 3.8.1")]
-        AUTOMATIC,
-        /// <summary>
-        /// The controller is operating in a single cycle, single block,  or single step mode.
-        /// </summary>
-        [MtconnectVersionApplicability(MtconnectVersions.V_1_1_0, "Part 3 Section 3.10.1")]
-        SEMI_AUTOMATIC,
-        /// <summary>
-        /// The controller is under manual control by the operator.
-        /// </summary>
-        [MtconnectVersionApplicability(MtconnectVersions.V_1_0_1, "Part 3 Section 3.8.1")]
-        MANUAL,
-        /// <summary>
-        /// The operator can enter operations for the controller to  perform. There is no current program being executed.
-        /// </summary>
-        [MtconnectVersionApplicability(MtconnectVersions.V_1_0_1, "Part 3 Section 3.8.1")]
-        MANUAL_DATA_INPUT,
-        /// <summary>
-        /// The controller is currently editing a program in the  foreground.
-        /// </summary>
-        [MtconnectVersionApplicability(MtconnectVersions.V_1_3_0, "Part 3 Section 3.10.3")]
-        EDIT,
-        /// <summary>
-        /// The machine is executing single block or instruction.
-        /// </summary>
-        [Obsolete("Deprecated in version 1.4.0. See CONTROLLER_MODE_OVERRIDE.")]
-        [MtconnectVersionApplicability(MtconnectVersions.V_1_3_0, "Part 3 Section 3.10.3", MtconnectVersions.V_1_3_1)]
-        SINGLE_BLOCK,
-        /// <summary>
-        /// The axes of the device are commanded to stop, but the  spindle continues to function.
-        /// </summary>
-        [Obsolete("Deprecated in version 1.3.0.")]
-        [MtconnectVersionApplicability(MtconnectVersions.V_1_2_0, "Part 3 Section 3.10.2", MtconnectVersions.V_1_2_0)]
-        FEED_HOLD
-    }
+	/// <summary>
+	/// View in the MTConnect Model browser <seealso href="https://model.mtconnect.org/#Enumeration__">model.mtconnect.org</seealso>
+	﻿	/// </summary>
+	[MtconnectVersionApplicability(MtconnectVersions.V_1_0_1, "https://model.mtconnect.org/")]
+	[GeneratedCode("MtconnectTranspiler.Sinks.MtconnectCore", "0.0.12.0")]
+	public enum ControllerModeValues
+	{
+		/// <summary>
+		﻿/// <see cref="Controller">Controller</see> is configured to automatically execute a program.
+		/// </summary>
+		[MtconnectVersionApplicability(MtconnectVersions.V_1_0_1, "https://model.mtconnect.org/")]
+		AUTOMATIC,
+		/// <summary>
+		﻿/// <see cref="Controller">Controller</see> is not executing an active program.   It is capable of receiving instructions from an external source – typically an operator. The <see cref="Controller">Controller</see> executes operations based on the instructions received from the external source.
+		/// </summary>
+		[MtconnectVersionApplicability(MtconnectVersions.V_1_0_1, "https://model.mtconnect.org/")]
+		MANUAL,
+		/// <summary>
+		﻿/// operator can enter a series of operations for the <see cref="Controller">Controller</see> to perform.  The <see cref="Controller">Controller</see> will execute this specific series of operations and then stop.
+		/// </summary>
+		[MtconnectVersionApplicability(MtconnectVersions.V_1_0_1, "https://model.mtconnect.org/")]
+		MANUAL_DATA_INPUT,
+		/// <summary>
+		﻿/// <see cref="Controller">Controller</see> is operating in a mode that restricts the active program from processing its next process step without operator intervention.
+		/// </summary>
+		[MtconnectVersionApplicability(MtconnectVersions.V_1_1_0, "https://model.mtconnect.org/")]
+		SEMI_AUTOMATIC,
+		/// <summary>
+		﻿/// <see cref="Controller">Controller</see> is currently functioning as a programming device and is not capable of executing an active program.
+		/// </summary>
+		[MtconnectVersionApplicability(MtconnectVersions.V_1_3_0, "https://model.mtconnect.org/")]
+		EDIT,
+		/// <summary>
+		﻿/// axes of the device are commanded to stop, but the spindle continues to function.
+		/// </summary>
+		[Obsolete("Deprecated according to https://model.mtconnect.org/")]
+		[MtconnectVersionApplicability(MtconnectVersions.V_1_2_0, "https://model.mtconnect.org/", MtconnectVersions.V_1_3_0)]
+		FEED_HOLD,
+	}
 }

--- a/MtconnectCore/Standard/Contracts/Enums/Streams/DirectionValues.cs
+++ b/MtconnectCore/Standard/Contracts/Enums/Streams/DirectionValues.cs
@@ -1,0 +1,38 @@
+using System;
+using System.CodeDom.Compiler;
+using MtconnectCore.Standard.Contracts.Attributes;
+
+namespace MtconnectCore.Standard.Contracts.Enums.Streams
+{
+	/// <summary>
+	/// View in the MTConnect Model browser <seealso href="https://model.mtconnect.org/#Enumeration__">model.mtconnect.org</seealso>
+	﻿	/// </summary>
+	[Obsolete("Deprecated according to https://model.mtconnect.org/")]
+	[MtconnectVersionApplicability(MtconnectVersions.V_1_0_1, "https://model.mtconnect.org/", MtconnectVersions.V_1_4_0)]
+	[GeneratedCode("MtconnectTranspiler.Sinks.MtconnectCore", "0.0.12.0")]
+	public enum DirectionValues
+	{
+		/// <summary>
+		﻿/// clockwise rotation using the right-hand rule.
+		/// </summary>
+		[Obsolete("Deprecated according to https://model.mtconnect.org/")]
+		[MtconnectVersionApplicability(MtconnectVersions.V_1_0_1, "https://model.mtconnect.org/", MtconnectVersions.V_1_4_0)]
+		CLOCKWISE,
+		/// <summary>
+		﻿/// counter-clockwise rotation using the right-hand rule.
+		/// </summary>
+		[Obsolete("Deprecated according to https://model.mtconnect.org/")]
+		[MtconnectVersionApplicability(MtconnectVersions.V_1_0_1, "https://model.mtconnect.org/", MtconnectVersions.V_1_4_0)]
+		COUNTER_CLOCKWISE,
+		/// <summary>
+		﻿		/// </summary>
+		[Obsolete("Deprecated according to https://model.mtconnect.org/")]
+		[MtconnectVersionApplicability(MtconnectVersions.V_1_2_0, "https://model.mtconnect.org/", MtconnectVersions.V_1_4_0)]
+		POSITIVE,
+		/// <summary>
+		﻿		/// </summary>
+		[Obsolete("Deprecated according to https://model.mtconnect.org/")]
+		[MtconnectVersionApplicability(MtconnectVersions.V_1_2_0, "https://model.mtconnect.org/", MtconnectVersions.V_1_4_0)]
+		NEGATIVE,
+	}
+}

--- a/MtconnectCore/Standard/Contracts/Enums/Streams/DoorStateValues.cs
+++ b/MtconnectCore/Standard/Contracts/Enums/Streams/DoorStateValues.cs
@@ -1,27 +1,30 @@
-﻿using MtconnectCore.Standard.Contracts.Attributes;
-using MtconnectCore.Standard.Contracts.Enums.Devices.DataItemTypes;
+using System;
+using System.CodeDom.Compiler;
+using MtconnectCore.Standard.Contracts.Attributes;
 
 namespace MtconnectCore.Standard.Contracts.Enums.Streams
 {
-    /// <summary>
-    /// Available values for EVENT element <see cref="EventTypes.DOOR_STATE"/>
-    /// </summary>
-    [MtconnectVersionApplicability(MtconnectVersions.V_1_1_0, "Part 3 Section 3.10.1")]
-    public enum DoorStateValues {
-        /// <summary>
-        /// The door is opened.
-        /// </summary>
-        [MtconnectVersionApplicability(MtconnectVersions.V_1_1_0, "Part 3 Section 3.10.1")]
-        OPEN,
-        /// <summary>
-        /// The door is closed.
-        /// </summary>
-        [MtconnectVersionApplicability(MtconnectVersions.V_1_1_0, "Part 3 Section 3.10.1")]
-        CLOSED,
-        /// <summary>
-        /// The door is not closed to the point of a positive  confirmation and not open to the point of a positive confirmation
-        /// </summary>
-        [MtconnectVersionApplicability(MtconnectVersions.V_1_2_0, "Part 3 Section 3.10.2")]
-        UNLATCHED
-    }
+	/// <summary>
+	/// View in the MTConnect Model browser <seealso href="https://model.mtconnect.org/#Enumeration__">model.mtconnect.org</seealso>
+	﻿	/// </summary>
+	[MtconnectVersionApplicability(MtconnectVersions.V_1_1_0, "https://model.mtconnect.org/")]
+	[GeneratedCode("MtconnectTranspiler.Sinks.MtconnectCore", "0.0.12.0")]
+	public enum DoorStateValues
+	{
+		/// <summary>
+		﻿/// <see cref="Door">Door</see> is open to the point of a positive confirmation.
+		/// </summary>
+		[MtconnectVersionApplicability(MtconnectVersions.V_1_1_0, "https://model.mtconnect.org/")]
+		OPEN,
+		/// <summary>
+		﻿/// <see cref="Door">Door</see> is closed to the point of a positive confirmation.
+		/// </summary>
+		[MtconnectVersionApplicability(MtconnectVersions.V_1_1_0, "https://model.mtconnect.org/")]
+		CLOSED,
+		/// <summary>
+		﻿/// <see cref="Door">Door</see> is not closed to the point of a positive confirmation and not open to the point of a positive confirmation.   It is in an intermediate position.
+		/// </summary>
+		[MtconnectVersionApplicability(MtconnectVersions.V_1_2_0, "https://model.mtconnect.org/")]
+		UNLATCHED,
+	}
 }

--- a/MtconnectCore/Standard/Contracts/Enums/Streams/EmergencyStopValues.cs
+++ b/MtconnectCore/Standard/Contracts/Enums/Streams/EmergencyStopValues.cs
@@ -1,23 +1,25 @@
-﻿using MtconnectCore.Standard.Contracts.Attributes;
-using MtconnectCore.Standard.Contracts.Enums.Devices.DataItemTypes;
+using System;
+using System.CodeDom.Compiler;
+using MtconnectCore.Standard.Contracts.Attributes;
 
 namespace MtconnectCore.Standard.Contracts.Enums.Streams
 {
-    /// <summary>
-    /// Available values for EVENT element <see cref="EventTypes.EMERGENCY_STOP"/>
-    /// </summary>
-    [MtconnectVersionApplicability(MtconnectVersions.V_1_1_0, "Part 3 Section 3.10.1")]
-    public enum EmergencyStopValues
-    {
-        /// <summary>
-        /// The circuit is complete and the device is operating.
-        /// </summary>
-        [MtconnectVersionApplicability(MtconnectVersions.V_1_1_0, "Part 3 Section 3.10.1")]
-        ARMED,
-        /// <summary>
-        /// The circuit is open and the device must cease operation.
-        /// </summary>
-        [MtconnectVersionApplicability(MtconnectVersions.V_1_1_0, "Part 3 Section 3.10.1")]
-        TRIGGERED
-    }
+	/// <summary>
+	/// View in the MTConnect Model browser <seealso href="https://model.mtconnect.org/#Enumeration__">model.mtconnect.org</seealso>
+	﻿	/// </summary>
+	[MtconnectVersionApplicability(MtconnectVersions.V_1_1_0, "https://model.mtconnect.org/")]
+	[GeneratedCode("MtconnectTranspiler.Sinks.MtconnectCore", "0.0.12.0")]
+	public enum EmergencyStopValues
+	{
+		/// <summary>
+		﻿/// emergency stop circuit is complete and the piece of equipment, component, or composition is allowed to operate. 
+		/// </summary>
+		[MtconnectVersionApplicability(MtconnectVersions.V_1_1_0, "https://model.mtconnect.org/")]
+		ARMED,
+		/// <summary>
+		﻿/// operation of the piece of equipment, component, or composition is inhibited.
+		/// </summary>
+		[MtconnectVersionApplicability(MtconnectVersions.V_1_1_0, "https://model.mtconnect.org/")]
+		TRIGGERED,
+	}
 }

--- a/MtconnectCore/Standard/Contracts/Enums/Streams/EndOfBarValues.cs
+++ b/MtconnectCore/Standard/Contracts/Enums/Streams/EndOfBarValues.cs
@@ -1,23 +1,25 @@
-﻿using MtconnectCore.Standard.Contracts.Attributes;
-using MtconnectCore.Standard.Contracts.Enums.Devices.DataItemTypes;
+using System;
+using System.CodeDom.Compiler;
+using MtconnectCore.Standard.Contracts.Attributes;
 
 namespace MtconnectCore.Standard.Contracts.Enums.Streams
 {
-    /// <summary>
-    /// Available values for EVENT element <see cref="EventTypes.END_OF_BAR"/>
-    /// </summary>
-    [MtconnectVersionApplicability(MtconnectVersions.V_1_3_0, "Part 3 Section 3.10.3")]
-    public enum EndOfBarValues
-    {
-        /// <summary>
-        /// The end of bar has been reached
-        /// </summary>
-        [MtconnectVersionApplicability(MtconnectVersions.V_1_3_0, "Part 3 Section 3.10.3")]
-        YES,
-        /// <summary>
-        /// The end of bar has not been reached
-        /// </summary>
-        [MtconnectVersionApplicability(MtconnectVersions.V_1_3_0, "Part 3 Section 3.10.3")]
-        NO
-    }
+	/// <summary>
+	/// View in the MTConnect Model browser <seealso href="https://model.mtconnect.org/#Enumeration__">model.mtconnect.org</seealso>
+	﻿	/// </summary>
+	[MtconnectVersionApplicability(MtconnectVersions.V_1_3_0, "https://model.mtconnect.org/")]
+	[GeneratedCode("MtconnectTranspiler.Sinks.MtconnectCore", "0.0.12.0")]
+	public enum EndOfBarValues
+	{
+		/// <summary>
+		﻿/// <see cref="EndOfBar">EndOfBar</see> has been reached.
+		/// </summary>
+		[MtconnectVersionApplicability(MtconnectVersions.V_1_3_0, "https://model.mtconnect.org/")]
+		YES,
+		/// <summary>
+		﻿/// <see cref="EndOfBar">EndOfBar</see> has not been reached.
+		/// </summary>
+		[MtconnectVersionApplicability(MtconnectVersions.V_1_3_0, "https://model.mtconnect.org/")]
+		NO,
+	}
 }

--- a/MtconnectCore/Standard/Contracts/Enums/Streams/EquipmentModeValues.cs
+++ b/MtconnectCore/Standard/Contracts/Enums/Streams/EquipmentModeValues.cs
@@ -1,23 +1,25 @@
-﻿using MtconnectCore.Standard.Contracts.Attributes;
-using MtconnectCore.Standard.Contracts.Enums.Devices.DataItemTypes;
+using System;
+using System.CodeDom.Compiler;
+using MtconnectCore.Standard.Contracts.Attributes;
 
 namespace MtconnectCore.Standard.Contracts.Enums.Streams
 {
-    /// <summary>
-    /// Available values for EVENT element <see cref="EventTypes.EQUIPMENT_MODE"/>
-    /// </summary>
-    [MtconnectVersionApplicability(MtconnectVersions.V_1_4_0, "Part 3 Section 6.2")]
-    public enum EquipmentModeValues
-    {
-        /// <summary>
-        /// The equipment is functioning in the mode  designated by the subType
-        /// </summary>
-        [MtconnectVersionApplicability(MtconnectVersions.V_1_4_0, "Part 3 Section 6.2")]
-        ON,
-        /// <summary>
-        /// The equipment is not functioning in th mode designated by the subType.
-        /// </summary>
-        [MtconnectVersionApplicability(MtconnectVersions.V_1_4_0, "Part 3 Section 6.2")]
-        OFF
-    }
+	/// <summary>
+	/// View in the MTConnect Model browser <seealso href="https://model.mtconnect.org/#Enumeration__">model.mtconnect.org</seealso>
+	﻿	/// </summary>
+	[MtconnectVersionApplicability(MtconnectVersions.V_1_4_0, "https://model.mtconnect.org/")]
+	[GeneratedCode("MtconnectTranspiler.Sinks.MtconnectCore", "0.0.12.0")]
+	public enum EquipmentModeValues
+	{
+		/// <summary>
+		﻿/// equipment is functioning in the mode designated by the <c>subType</c>.
+		/// </summary>
+		[MtconnectVersionApplicability(MtconnectVersions.V_1_4_0, "https://model.mtconnect.org/")]
+		ON,
+		/// <summary>
+		﻿/// equipment is not functioning in the mode designated by the <c>subType</c>.
+		/// </summary>
+		[MtconnectVersionApplicability(MtconnectVersions.V_1_4_0, "https://model.mtconnect.org/")]
+		OFF,
+	}
 }

--- a/MtconnectCore/Standard/Contracts/Enums/Streams/ExecutionValues.cs
+++ b/MtconnectCore/Standard/Contracts/Enums/Streams/ExecutionValues.cs
@@ -1,64 +1,60 @@
-﻿using MtconnectCore.Standard.Contracts.Attributes;
-using MtconnectCore.Standard.Contracts.Enums.Devices.DataItemTypes;
 using System;
+using System.CodeDom.Compiler;
+using MtconnectCore.Standard.Contracts.Attributes;
 
 namespace MtconnectCore.Standard.Contracts.Enums.Streams
 {
-    /// <summary>
-    /// Available values for EVENT element <see cref="EventTypes.EXECUTION"/>
-    /// </summary>
-    [MtconnectVersionApplicability(MtconnectVersions.V_1_0_1, "Part 3 Section 3.8.1")]
-    public enum ExecutionValues {
-        /// <summary>
-        /// The controller is ready to execute. It is currently idle.
-        /// </summary>
-        [MtconnectVersionApplicability(MtconnectVersions.V_1_0_1, "Part 3 Section 3.8.1")]
-        READY,
-        /// <summary>
-        /// The controller is actively executing an instruction.
-        /// </summary>
-        [MtconnectVersionApplicability(MtconnectVersions.V_1_0_1, "Part 3 Section 3.8.1")]
-        ACTIVE,
-        /// <summary>
-        /// The operator or the program has paused execution and is waiting to be continued.
-        /// </summary>
-        [MtconnectVersionApplicability(MtconnectVersions.V_1_0_1, "Part 3 Section 3.8.1")]
-        INTERRUPTED,
-        /// <summary>
-        /// The execution of the controller’s program is suspended while a secondary operation is executing or completing. Execution will resume automatically once the secondary operation is completed.
-        /// </summary>
-        [MtconnectVersionApplicability(MtconnectVersions.V_1_5_0, "Part 2 Section 6.2")]
-        WAIT,
-        /// <summary>
-        /// The controller has is in a feed hold and motion has  been stopped.
-        /// </summary>
-        [MtconnectVersionApplicability(MtconnectVersions.V_1_3_0, "Part 3 Section 3.10.3")]
-        FEED_HOLD,
-        /// <summary>
-        /// The controller has been stopped.
-        /// </summary>
-        [MtconnectVersionApplicability(MtconnectVersions.V_1_0_1, "Part 3 Section 3.8.1")]
-        STOPPED,
-        /// <summary>
-        /// The controller’s program has  been intentionally stopped using an M01 or similar command.The program may be stopped at the designated location based upon the state of a secondary indication provided to the controller indicating whether the program execution must be stopped at this location or program execution should continue.
-        /// </summary>
-        [MtconnectVersionApplicability(MtconnectVersions.V_1_4_0, "Part 3 Section 6.2")]
-        OPTIONAL_STOP,
-        /// <summary>
-        /// The program has been stopped.
-        /// </summary>
-        [MtconnectVersionApplicability(MtconnectVersions.V_1_3_0, "Part 3 Section 3.10.3")]
-        PROGRAM_STOPPED,
-        /// <summary>
-        /// The program has completed execution.
-        /// </summary>
-        [MtconnectVersionApplicability(MtconnectVersions.V_1_3_0, "Part 3 Section 3.10.3")]
-        PROGRAM_COMPLETED,
-        /// <summary>
-        /// The program has been intentionally optionally stopped using an M01 or similar code.
-        /// </summary>
-        [Obsolete("Deprecated in version 1.4.0. See OPTIONAL_STOP")]
-        [MtconnectVersionApplicability(MtconnectVersions.V_1_3_0, "Part 3 Section 3.10.3", MtconnectVersions.V_1_3_1)]
-        PROGRAM_OPTIONAL_STOP
-    }
+	/// <summary>
+	/// View in the MTConnect Model browser <seealso href="https://model.mtconnect.org/#Enumeration__">model.mtconnect.org</seealso>
+	﻿	/// </summary>
+	[MtconnectVersionApplicability(MtconnectVersions.V_1_0_1, "https://model.mtconnect.org/")]
+	[GeneratedCode("MtconnectTranspiler.Sinks.MtconnectCore", "0.0.12.0")]
+	public enum ExecutionValues
+	{
+		/// <summary>
+		﻿/// <see cref="Component">Component</see> is ready to execute instructions.  It is currently idle.
+		/// </summary>
+		[MtconnectVersionApplicability(MtconnectVersions.V_1_0_1, "https://model.mtconnect.org/")]
+		READY,
+		/// <summary>
+		﻿/// <see cref="Component">Component</see> is actively executing an instruction.
+		/// </summary>
+		[MtconnectVersionApplicability(MtconnectVersions.V_1_0_1, "https://model.mtconnect.org/")]
+		ACTIVE,
+		/// <summary>
+		﻿/// <see cref="Component">Component</see> suspends the execution of the program due to an external signal.  Action is required to resume execution.
+		/// </summary>
+		[MtconnectVersionApplicability(MtconnectVersions.V_1_0_1, "https://model.mtconnect.org/")]
+		INTERRUPTED,
+		/// <summary>
+		﻿/// motion of the active axes are commanded to stop at their current position.
+		/// </summary>
+		[MtconnectVersionApplicability(MtconnectVersions.V_1_3_0, "https://model.mtconnect.org/")]
+		FEED_HOLD,
+		/// <summary>
+		﻿/// <see cref="Component">Component</see> program is not <c>READY</c> to execute.
+		/// </summary>
+		[MtconnectVersionApplicability(MtconnectVersions.V_1_0_1, "https://model.mtconnect.org/")]
+		STOPPED,
+		/// <summary>
+		﻿/// command from the program has intentionally interrupted execution.  The <see cref="Component">Component</see> <b>MAY</b> have another state that indicates if the execution is interrupted or the execution ignores the interrupt instruction.
+		/// </summary>
+		[MtconnectVersionApplicability(MtconnectVersions.V_1_3_0, "https://model.mtconnect.org/")]
+		OPTIONAL_STOP,
+		/// <summary>
+		﻿/// command from the program has intentionally interrupted execution.  Action is required to resume execution.
+		/// </summary>
+		[MtconnectVersionApplicability(MtconnectVersions.V_1_3_0, "https://model.mtconnect.org/")]
+		PROGRAM_STOPPED,
+		/// <summary>
+		﻿/// program completed execution.
+		/// </summary>
+		[MtconnectVersionApplicability(MtconnectVersions.V_1_3_0, "https://model.mtconnect.org/")]
+		PROGRAM_COMPLETED,
+		/// <summary>
+		﻿/// <see cref="Component">Component</see> suspends execution while a secondary operation executes.  Execution resumes automatically once the secondary operation completes.
+		/// </summary>
+		[MtconnectVersionApplicability(MtconnectVersions.V_1_5_0, "https://model.mtconnect.org/")]
+		WAIT,
+	}
 }

--- a/MtconnectCore/Standard/Contracts/Enums/Streams/FunctionalModeValues.cs
+++ b/MtconnectCore/Standard/Contracts/Enums/Streams/FunctionalModeValues.cs
@@ -1,38 +1,40 @@
-﻿using MtconnectCore.Standard.Contracts.Attributes;
-using MtconnectCore.Standard.Contracts.Enums.Devices.DataItemTypes;
+using System;
+using System.CodeDom.Compiler;
+using MtconnectCore.Standard.Contracts.Attributes;
 
 namespace MtconnectCore.Standard.Contracts.Enums.Streams
 {
-    /// <summary>
-    /// Available values for EVENT element <see cref="EventTypes.FUNCTIONAL_MODE"/>
-    /// </summary>
-    [MtconnectVersionApplicability(MtconnectVersions.V_1_3_0, "Part 3 Section 3.10.3")]
-    public enum FunctionalModeValues
-    {
-        /// <summary>
-        /// The device is ready for automated production.
-        /// </summary>
-        [MtconnectVersionApplicability(MtconnectVersions.V_1_3_0, "Part 3 Section 3.10.3")]
-        PRODUCTION,
-        /// <summary>
-        /// The device is being setup for a new part type.
-        /// </summary>
-        [MtconnectVersionApplicability(MtconnectVersions.V_1_3_0, "Part 3 Section 3.10.3")]
-        SETUP,
-        /// <summary>
-        /// The current setup is being removed from the device.
-        /// </summary>
-        [MtconnectVersionApplicability(MtconnectVersions.V_1_3_0, "Part 3 Section 3.10.3")]
-        TEARDOWN,
-        /// <summary>
-        /// The device is being repaired or routine service is being  performed.
-        /// </summary>
-        [MtconnectVersionApplicability(MtconnectVersions.V_1_3_0, "Part 3 Section 3.10.3")]
-        MAINTENANCE,
-        /// <summary>
-        /// The device is being used to prove-out a new process.
-        /// </summary>
-        [MtconnectVersionApplicability(MtconnectVersions.V_1_3_0, "Part 3 Section 3.10.3")]
-        PROCESS_DEVELOPMENT
-    }
+	/// <summary>
+	/// View in the MTConnect Model browser <seealso href="https://model.mtconnect.org/#Enumeration__">model.mtconnect.org</seealso>
+	﻿	/// </summary>
+	[MtconnectVersionApplicability(MtconnectVersions.V_1_3_0, "https://model.mtconnect.org/")]
+	[GeneratedCode("MtconnectTranspiler.Sinks.MtconnectCore", "0.0.12.0")]
+	public enum FunctionalModeValues
+	{
+		/// <summary>
+		﻿/// <see cref="Component">Component</see> is currently producing product, ready to produce product, or its current intended use is to be producing product.
+		/// </summary>
+		[MtconnectVersionApplicability(MtconnectVersions.V_1_3_0, "https://model.mtconnect.org/")]
+		PRODUCTION,
+		/// <summary>
+		﻿/// <see cref="Component">Component</see> is not currently producing product.   It is being prepared or modified to begin production of product.
+		/// </summary>
+		[MtconnectVersionApplicability(MtconnectVersions.V_1_3_0, "https://model.mtconnect.org/")]
+		SETUP,
+		/// <summary>
+		﻿/// <see cref="Component">Component</see> is not currently producing product.  Typically, it has completed the production of a product and is being modified or returned to a neutral state such that it may then be prepared to begin production of a different product.
+		/// </summary>
+		[MtconnectVersionApplicability(MtconnectVersions.V_1_3_0, "https://model.mtconnect.org/")]
+		TEARDOWN,
+		/// <summary>
+		﻿/// <see cref="Component">Component</see> is not currently producing product.  It is currently being repaired, waiting to be repaired, or has not yet been returned to a normal production status after maintenance has been performed.
+		/// </summary>
+		[MtconnectVersionApplicability(MtconnectVersions.V_1_3_0, "https://model.mtconnect.org/")]
+		MAINTENANCE,
+		/// <summary>
+		﻿/// <see cref="Component">Component</see> is being used to prove-out a new process, testing of equipment or processes, or any other active use that does not result in the production of product.
+		/// </summary>
+		[MtconnectVersionApplicability(MtconnectVersions.V_1_3_0, "https://model.mtconnect.org/")]
+		PROCESS_DEVELOPMENT,
+	}
 }

--- a/MtconnectCore/Standard/Contracts/Enums/Streams/LeakDetectValues.cs
+++ b/MtconnectCore/Standard/Contracts/Enums/Streams/LeakDetectValues.cs
@@ -7,19 +7,19 @@ namespace MtconnectCore.Standard.Contracts.Enums.Streams
 	/// <summary>
 	/// View in the MTConnect Model browser <seealso href="https://model.mtconnect.org/#Enumeration__">model.mtconnect.org</seealso>
 	﻿	/// </summary>
-	[MtconnectVersionApplicability(MtconnectVersions.V_1_2_0, "https://model.mtconnect.org/")]
+	[MtconnectVersionApplicability(MtconnectVersions.V_2_1_0, "https://model.mtconnect.org/")]
 	[GeneratedCode("MtconnectTranspiler.Sinks.MtconnectCore", "0.0.12.0")]
-	public enum ActuatorStateValues
+	public enum LeakDetectValues
 	{
 		/// <summary>
-		﻿/// <see cref="Actuator">Actuator</see> is operating.
+		﻿/// leak is currently being detected.
 		/// </summary>
-		[MtconnectVersionApplicability(MtconnectVersions.V_1_2_0, "https://model.mtconnect.org/")]
-		ACTIVE,
+		[MtconnectVersionApplicability(MtconnectVersions.V_2_1_0, "https://model.mtconnect.org/")]
+		DETECTED,
 		/// <summary>
-		﻿/// <see cref="Actuator">Actuator</see> is not operating.
+		﻿/// leak is currently not being detected.
 		/// </summary>
-		[MtconnectVersionApplicability(MtconnectVersions.V_1_2_0, "https://model.mtconnect.org/")]
-		INACTIVE,
+		[MtconnectVersionApplicability(MtconnectVersions.V_2_1_0, "https://model.mtconnect.org/")]
+		NOT_DETECTED,
 	}
 }

--- a/MtconnectCore/Standard/Contracts/Enums/Streams/LockStateValues.cs
+++ b/MtconnectCore/Standard/Contracts/Enums/Streams/LockStateValues.cs
@@ -1,0 +1,25 @@
+using System;
+using System.CodeDom.Compiler;
+using MtconnectCore.Standard.Contracts.Attributes;
+
+namespace MtconnectCore.Standard.Contracts.Enums.Streams
+{
+	/// <summary>
+	/// View in the MTConnect Model browser <seealso href="https://model.mtconnect.org/#Enumeration__">model.mtconnect.org</seealso>
+	﻿	/// </summary>
+	[MtconnectVersionApplicability(MtconnectVersions.V_1_8_0, "https://model.mtconnect.org/")]
+	[GeneratedCode("MtconnectTranspiler.Sinks.MtconnectCore", "0.0.12.0")]
+	public enum LockStateValues
+	{
+		/// <summary>
+		﻿/// mechanism is engaged and preventing the associated <see cref="Component">Component</see> from being opened or operated.
+		/// </summary>
+		[MtconnectVersionApplicability(MtconnectVersions.V_1_8_0, "https://model.mtconnect.org/")]
+		LOCKED,
+		/// <summary>
+		﻿/// mechanism is disengaged and the associated <see cref="Component">Component</see> is able to be opened or operated.
+		/// </summary>
+		[MtconnectVersionApplicability(MtconnectVersions.V_1_8_0, "https://model.mtconnect.org/")]
+		UNLOCKED,
+	}
+}

--- a/MtconnectCore/Standard/Contracts/Enums/Streams/OperatingModeValues.cs
+++ b/MtconnectCore/Standard/Contracts/Enums/Streams/OperatingModeValues.cs
@@ -1,0 +1,30 @@
+using System;
+using System.CodeDom.Compiler;
+using MtconnectCore.Standard.Contracts.Attributes;
+
+namespace MtconnectCore.Standard.Contracts.Enums.Streams
+{
+	/// <summary>
+	/// View in the MTConnect Model browser <seealso href="https://model.mtconnect.org/#Enumeration__">model.mtconnect.org</seealso>
+	﻿	/// </summary>
+	[MtconnectVersionApplicability(MtconnectVersions.V_2_0_0, "https://model.mtconnect.org/")]
+	[GeneratedCode("MtconnectTranspiler.Sinks.MtconnectCore", "0.0.12.0")]
+	public enum OperatingModeValues
+	{
+		/// <summary>
+		﻿/// automatically execute instructions from a recipe or program.  > Note: Setpoint comes from a recipe.
+		/// </summary>
+		[MtconnectVersionApplicability(MtconnectVersions.V_2_0_0, "https://model.mtconnect.org/")]
+		AUTOMATIC,
+		/// <summary>
+		﻿/// execute instructions from an external agent or person.  > Note 1 to entry: Valve or switch is manipulated by an agent/person.  > Note 2 to entry: Direct control of the PID output. % of the range: A user manually sets the % output, not the setpoint.
+		/// </summary>
+		[MtconnectVersionApplicability(MtconnectVersions.V_2_0_0, "https://model.mtconnect.org/")]
+		MANUAL,
+		/// <summary>
+		﻿/// executes a single instruction from a recipe or program.  > Note 1 to entry: Setpoint is entered and fixed, but the PID is controlling.  > Note 2 to entry: Still goes through the PID control system.  > Note 3 to entry: Manual fixed entry from a recipe.
+		/// </summary>
+		[MtconnectVersionApplicability(MtconnectVersions.V_2_0_0, "https://model.mtconnect.org/")]
+		SEMI_AUTOMATIC,
+	}
+}

--- a/MtconnectCore/Standard/Contracts/Enums/Streams/PartCountTypeValues.cs
+++ b/MtconnectCore/Standard/Contracts/Enums/Streams/PartCountTypeValues.cs
@@ -7,19 +7,19 @@ namespace MtconnectCore.Standard.Contracts.Enums.Streams
 	/// <summary>
 	/// View in the MTConnect Model browser <seealso href="https://model.mtconnect.org/#Enumeration__">model.mtconnect.org</seealso>
 	﻿	/// </summary>
-	[MtconnectVersionApplicability(MtconnectVersions.V_1_2_0, "https://model.mtconnect.org/")]
+	[MtconnectVersionApplicability(MtconnectVersions.V_2_0_0, "https://model.mtconnect.org/")]
 	[GeneratedCode("MtconnectTranspiler.Sinks.MtconnectCore", "0.0.12.0")]
-	public enum ActuatorStateValues
+	public enum PartCountTypeValues
 	{
 		/// <summary>
-		﻿/// <see cref="Actuator">Actuator</see> is operating.
+		﻿/// count is of individual items.
 		/// </summary>
-		[MtconnectVersionApplicability(MtconnectVersions.V_1_2_0, "https://model.mtconnect.org/")]
-		ACTIVE,
+		[MtconnectVersionApplicability(MtconnectVersions.V_2_0_0, "https://model.mtconnect.org/")]
+		EACH,
 		/// <summary>
-		﻿/// <see cref="Actuator">Actuator</see> is not operating.
+		﻿/// pre-specified group of items.
 		/// </summary>
-		[MtconnectVersionApplicability(MtconnectVersions.V_1_2_0, "https://model.mtconnect.org/")]
-		INACTIVE,
+		[MtconnectVersionApplicability(MtconnectVersions.V_2_0_0, "https://model.mtconnect.org/")]
+		BATCH,
 	}
 }

--- a/MtconnectCore/Standard/Contracts/Enums/Streams/PartDetectValues.cs
+++ b/MtconnectCore/Standard/Contracts/Enums/Streams/PartDetectValues.cs
@@ -1,23 +1,25 @@
-﻿using MtconnectCore.Standard.Contracts.Attributes;
-using MtconnectCore.Standard.Contracts.Enums.Devices.DataItemTypes;
+using System;
+using System.CodeDom.Compiler;
+using MtconnectCore.Standard.Contracts.Attributes;
 
 namespace MtconnectCore.Standard.Contracts.Enums.Streams
 {
-    /// <summary>
-    /// Available values for EVENT element <see cref="EventTypes.PART_DETECT"/>
-    /// </summary>
-    [MtconnectVersionApplicability(MtconnectVersions.V_1_5_0, "Part 3 Section 6.2")]
-    public enum PartDetectValues
-    {
-        /// <summary>
-        /// If a part or work piece has been detected or is present.
-        /// </summary>
-        [MtconnectVersionApplicability(MtconnectVersions.V_1_5_0, "Part 3 Section 6.2")]
-        PRESENT,
-        /// <summary>
-        /// If a part or work piece is not detected or is not present.
-        /// </summary>
-        [MtconnectVersionApplicability(MtconnectVersions.V_1_5_0, "Part 3 Section 6.2")]
-        NOT_PRESENT
-    }
+	/// <summary>
+	/// View in the MTConnect Model browser <seealso href="https://model.mtconnect.org/#Enumeration__">model.mtconnect.org</seealso>
+	﻿	/// </summary>
+	[MtconnectVersionApplicability(MtconnectVersions.V_1_5_0, "https://model.mtconnect.org/")]
+	[GeneratedCode("MtconnectTranspiler.Sinks.MtconnectCore", "0.0.12.0")]
+	public enum PartDetectValues
+	{
+		/// <summary>
+		﻿/// part or work piece is detected or is present.
+		/// </summary>
+		[MtconnectVersionApplicability(MtconnectVersions.V_1_5_0, "https://model.mtconnect.org/")]
+		PRESENT,
+		/// <summary>
+		﻿/// part or work piece is not detected or is not present.
+		/// </summary>
+		[MtconnectVersionApplicability(MtconnectVersions.V_1_5_0, "https://model.mtconnect.org/")]
+		NOT_PRESENT,
+	}
 }

--- a/MtconnectCore/Standard/Contracts/Enums/Streams/PartProcessingStateValues.cs
+++ b/MtconnectCore/Standard/Contracts/Enums/Streams/PartProcessingStateValues.cs
@@ -1,0 +1,75 @@
+using System;
+using System.CodeDom.Compiler;
+using MtconnectCore.Standard.Contracts.Attributes;
+
+namespace MtconnectCore.Standard.Contracts.Enums.Streams
+{
+	/// <summary>
+	/// View in the MTConnect Model browser <seealso href="https://model.mtconnect.org/#Enumeration__">model.mtconnect.org</seealso>
+	﻿	/// </summary>
+	[MtconnectVersionApplicability(MtconnectVersions.V_1_8_0, "https://model.mtconnect.org/")]
+	[GeneratedCode("MtconnectTranspiler.Sinks.MtconnectCore", "0.0.12.0")]
+	public enum PartProcessingStateValues
+	{
+		/// <summary>
+		﻿/// part occurrence is not actively being processed, but the processing has not ended.   Processing requirements exist that have not yet been fulfilled. This is the default entry state when the part occurrence is originally received. In some cases, the part occurrence may return to this state while it waits for additional processing to be performed.
+		/// </summary>
+		[MtconnectVersionApplicability(MtconnectVersions.V_1_8_0, "https://model.mtconnect.org/")]
+		NEEDS_PROCESSING,
+		/// <summary>
+		﻿/// part occurrence is actively being processed.
+		/// </summary>
+		[MtconnectVersionApplicability(MtconnectVersions.V_1_8_0, "https://model.mtconnect.org/")]
+		IN_PROCESS,
+		/// <summary>
+		﻿/// part occurrence is no longer being processed.   A general state when the reason for termination is unknown.
+		/// </summary>
+		[MtconnectVersionApplicability(MtconnectVersions.V_1_8_0, "https://model.mtconnect.org/")]
+		PROCESSING_ENDED,
+		/// <summary>
+		﻿/// part occurrence has completed processing successfully.
+		/// </summary>
+		[MtconnectVersionApplicability(MtconnectVersions.V_1_8_0, "https://model.mtconnect.org/")]
+		PROCESSING_ENDED_COMPLETE,
+		/// <summary>
+		﻿/// process has been stopped during the processing.   The part occurrence will require special treatment.
+		/// </summary>
+		[MtconnectVersionApplicability(MtconnectVersions.V_1_8_0, "https://model.mtconnect.org/")]
+		PROCESSING_ENDED_STOPPED,
+		/// <summary>
+		﻿/// processing of the part occurrence has come to a premature end.
+		/// </summary>
+		[MtconnectVersionApplicability(MtconnectVersions.V_1_8_0, "https://model.mtconnect.org/")]
+		PROCESSING_ENDED_ABORTED,
+		/// <summary>
+		﻿/// terminal state when the part occurrence has been removed from the equipment by an external entity and it no longer exists at the equipment.
+		/// </summary>
+		[MtconnectVersionApplicability(MtconnectVersions.V_1_8_0, "https://model.mtconnect.org/")]
+		PROCESSING_ENDED_LOST,
+		/// <summary>
+		﻿/// part occurrence has been skipped for processing on the piece of equipment.
+		/// </summary>
+		[MtconnectVersionApplicability(MtconnectVersions.V_1_8_0, "https://model.mtconnect.org/")]
+		PROCESSING_ENDED_SKIPPED,
+		/// <summary>
+		﻿/// part occurrence has been processed completely. However, the processing may have a problem.
+		/// </summary>
+		[MtconnectVersionApplicability(MtconnectVersions.V_1_8_0, "https://model.mtconnect.org/")]
+		PROCESSING_ENDED_REJECTED,
+		/// <summary>
+		﻿/// part occurrence is waiting for transit.
+		/// </summary>
+		[MtconnectVersionApplicability(MtconnectVersions.V_1_8_0, "https://model.mtconnect.org/")]
+		WAITING_FOR_TRANSIT,
+		/// <summary>
+		﻿/// part occurrence is being transported to its destination.
+		/// </summary>
+		[MtconnectVersionApplicability(MtconnectVersions.V_1_8_0, "https://model.mtconnect.org/")]
+		IN_TRANSIT,
+		/// <summary>
+		﻿/// part occurrence has been placed at its designated destination.
+		/// </summary>
+		[MtconnectVersionApplicability(MtconnectVersions.V_1_8_0, "https://model.mtconnect.org/")]
+		TRANSIT_COMPLETE,
+	}
+}

--- a/MtconnectCore/Standard/Contracts/Enums/Streams/PartStatusValues.cs
+++ b/MtconnectCore/Standard/Contracts/Enums/Streams/PartStatusValues.cs
@@ -1,23 +1,25 @@
-﻿using MtconnectCore.Standard.Contracts.Attributes;
-using MtconnectCore.Standard.Contracts.Enums.Devices.DataItemTypes;
+using System;
+using System.CodeDom.Compiler;
+using MtconnectCore.Standard.Contracts.Attributes;
 
 namespace MtconnectCore.Standard.Contracts.Enums.Streams
 {
-    /// <summary>
-    /// Available values for EVENT element <see cref="EventTypes.PART_STATUS"/>
-    /// </summary>
-    [MtconnectVersionApplicability(MtconnectVersions.V_1_7_0, "Part 3 Section 6.2")]
-    public enum PartStatusValues
-    {
-        /// <summary>
-        /// The part does conform to given requirements.
-        /// </summary>
-        [MtconnectVersionApplicability(MtconnectVersions.V_1_7_0, "Part 3 Section 6.2")]
-        PASS,
-        /// <summary>
-        /// The part does not conform to some given requirements.
-        /// </summary>
-        [MtconnectVersionApplicability(MtconnectVersions.V_1_7_0, "Part 3 Section 6.2")]
-        FAIL
-    }
+	/// <summary>
+	/// View in the MTConnect Model browser <seealso href="https://model.mtconnect.org/#Enumeration__">model.mtconnect.org</seealso>
+	﻿	/// </summary>
+	[MtconnectVersionApplicability(MtconnectVersions.V_1_7_0, "https://model.mtconnect.org/")]
+	[GeneratedCode("MtconnectTranspiler.Sinks.MtconnectCore", "0.0.12.0")]
+	public enum PartStatusValues
+	{
+		/// <summary>
+		﻿/// part conforms to given requirements.
+		/// </summary>
+		[MtconnectVersionApplicability(MtconnectVersions.V_1_7_0, "https://model.mtconnect.org/")]
+		PASS,
+		/// <summary>
+		﻿/// part does not conform to some given requirements.
+		/// </summary>
+		[MtconnectVersionApplicability(MtconnectVersions.V_1_7_0, "https://model.mtconnect.org/")]
+		FAIL,
+	}
 }

--- a/MtconnectCore/Standard/Contracts/Enums/Streams/PathModeValues.cs
+++ b/MtconnectCore/Standard/Contracts/Enums/Streams/PathModeValues.cs
@@ -1,33 +1,35 @@
-﻿using MtconnectCore.Standard.Contracts.Attributes;
-using MtconnectCore.Standard.Contracts.Enums.Devices.DataItemTypes;
+using System;
+using System.CodeDom.Compiler;
+using MtconnectCore.Standard.Contracts.Attributes;
 
 namespace MtconnectCore.Standard.Contracts.Enums.Streams
 {
-    /// <summary>
-    /// Available values for EVENT element <see cref="EventTypes.PATH_MODE"/>
-    /// </summary>
-    [MtconnectVersionApplicability(MtconnectVersions.V_1_1_0, "Part 3 Section 3.10.1")]
-    public enum PathModeValues
-    {
-        /// <summary>
-        /// A set of axes are operating independently and without the  influence of another set of axes.
-        /// </summary>
-        [MtconnectVersionApplicability(MtconnectVersions.V_1_1_0, "Part 3 Section 3.10.1")]
-        INDEPENDENT,
-        /// <summary>
-        /// The path provides the reference motion from which a  Synchronous or Mirror Path will follow.
-        /// </summary>
-        [MtconnectVersionApplicability(MtconnectVersions.V_1_2_0, "Part 3 Section 3.10.2")]
-        MASTER,
-        /// <summary>
-        /// The sets of axes are operating synchronously.
-        /// </summary>
-        [MtconnectVersionApplicability(MtconnectVersions.V_1_1_0, "Part 3 Section 3.10.1")]
-        SYNCHRONOUS,
-        /// <summary>
-        /// The sets of axes are mirroring each other.
-        /// </summary>
-        [MtconnectVersionApplicability(MtconnectVersions.V_1_1_0, "Part 3 Section 3.10.1")]
-        MIRROR
-    }
+	/// <summary>
+	/// View in the MTConnect Model browser <seealso href="https://model.mtconnect.org/#Enumeration__">model.mtconnect.org</seealso>
+	﻿	/// </summary>
+	[MtconnectVersionApplicability(MtconnectVersions.V_1_1_0, "https://model.mtconnect.org/")]
+	[GeneratedCode("MtconnectTranspiler.Sinks.MtconnectCore", "0.0.12.0")]
+	public enum PathModeValues
+	{
+		/// <summary>
+		﻿/// path is operating independently and without the influence of another path.
+		/// </summary>
+		[MtconnectVersionApplicability(MtconnectVersions.V_1_1_0, "https://model.mtconnect.org/")]
+		INDEPENDENT,
+		/// <summary>
+		﻿/// path provides information or state values that influences the operation of other <see cref="DataItem">DataItem</see> of similar type.
+		/// </summary>
+		[MtconnectVersionApplicability(MtconnectVersions.V_1_2_0, "https://model.mtconnect.org/")]
+		MASTER,
+		/// <summary>
+		﻿/// physical or logical parts which are not physically connected to each other but are operating together.
+		/// </summary>
+		[MtconnectVersionApplicability(MtconnectVersions.V_1_1_0, "https://model.mtconnect.org/")]
+		SYNCHRONOUS,
+		/// <summary>
+		﻿/// axes associated with the path are mirroring the motion of the <c>MASTER</c> path.
+		/// </summary>
+		[MtconnectVersionApplicability(MtconnectVersions.V_1_1_0, "https://model.mtconnect.org/")]
+		MIRROR,
+	}
 }

--- a/MtconnectCore/Standard/Contracts/Enums/Streams/PowerStateValues.cs
+++ b/MtconnectCore/Standard/Contracts/Enums/Streams/PowerStateValues.cs
@@ -1,23 +1,25 @@
-﻿using MtconnectCore.Standard.Contracts.Attributes;
-using MtconnectCore.Standard.Contracts.Enums.Devices.DataItemTypes;
+using System;
+using System.CodeDom.Compiler;
+using MtconnectCore.Standard.Contracts.Attributes;
 
 namespace MtconnectCore.Standard.Contracts.Enums.Streams
 {
-    /// <summary>
-    /// Available values for EVENT element <see cref="EventTypes.POWER_STATE"/>
-    /// </summary>
-    [MtconnectVersionApplicability(MtconnectVersions.V_1_1_0, "Part 3 Section 3.10.1")]
-    public enum PowerStateValues
-    {
-        /// <summary>
-        /// The power to the component is ON.
-        /// </summary>
-        [MtconnectVersionApplicability(MtconnectVersions.V_1_1_0, "Part 3 Section 3.10.1")]
-        ON,
-        /// <summary>
-        /// The power to the component is OFF.
-        /// </summary>
-        [MtconnectVersionApplicability(MtconnectVersions.V_1_1_0, "Part 3 Section 3.10.1")]
-        OFF
-    }
+	/// <summary>
+	/// View in the MTConnect Model browser <seealso href="https://model.mtconnect.org/#Enumeration__">model.mtconnect.org</seealso>
+	﻿	/// </summary>
+	[MtconnectVersionApplicability(MtconnectVersions.V_1_1_0, "https://model.mtconnect.org/")]
+	[GeneratedCode("MtconnectTranspiler.Sinks.MtconnectCore", "0.0.12.0")]
+	public enum PowerStateValues
+	{
+		/// <summary>
+		﻿/// source of energy for an entity or the enabling signal providing permission for the entity to perform its function(s) is present and active.
+		/// </summary>
+		[MtconnectVersionApplicability(MtconnectVersions.V_1_1_0, "https://model.mtconnect.org/")]
+		ON,
+		/// <summary>
+		﻿/// source of energy for an entity or the enabling signal providing permission for the entity to perform its function(s) is not present or is disconnected.
+		/// </summary>
+		[MtconnectVersionApplicability(MtconnectVersions.V_1_1_0, "https://model.mtconnect.org/")]
+		OFF,
+	}
 }

--- a/MtconnectCore/Standard/Contracts/Enums/Streams/PowerStatusValues.cs
+++ b/MtconnectCore/Standard/Contracts/Enums/Streams/PowerStatusValues.cs
@@ -1,27 +1,26 @@
-﻿using MtconnectCore.Standard.Contracts.Attributes;
-using MtconnectCore.Standard.Contracts.Enums.Devices.DataItemTypes;
 using System;
+using System.CodeDom.Compiler;
+using MtconnectCore.Standard.Contracts.Attributes;
 
 namespace MtconnectCore.Standard.Contracts.Enums.Streams
 {
-    /// <summary>
-    /// Available values for EVENT element <see cref="EventTypes.POWER_STATUS"/>
-    /// </summary>
-    [Obsolete("Deprecated in version 1.1.0.")]
-    [MtconnectVersionApplicability(MtconnectVersions.V_1_0_1, "Part 3 Section 3.8.1", MtconnectVersions.V_1_0_1)]
-    public enum PowerStatusValues
-    {
-        /// <summary>
-        /// The power to the component is ON.
-        /// </summary>
-        [Obsolete("Deprecated in version 1.1.0.")]
-        [MtconnectVersionApplicability(MtconnectVersions.V_1_0_1, "Part 3 Section 3.8.1", MtconnectVersions.V_1_0_1)]
-        ON,
-        /// <summary>
-        /// The power to the component is OFF.
-        /// </summary>
-        [Obsolete("Deprecated in version 1.1.0.")]
-        [MtconnectVersionApplicability(MtconnectVersions.V_1_0_1, "Part 3 Section 3.8.1", MtconnectVersions.V_1_0_1)]
-        OFF
-    }
+	/// <summary>
+	/// View in the MTConnect Model browser <seealso href="https://model.mtconnect.org/#Enumeration__">model.mtconnect.org</seealso>
+	﻿	/// </summary>
+	[Obsolete("Deprecated according to https://model.mtconnect.org/")]
+	[MtconnectVersionApplicability(MtconnectVersions.V_1_0_1, "https://model.mtconnect.org/", MtconnectVersions.V_1_1_0)]
+	[GeneratedCode("MtconnectTranspiler.Sinks.MtconnectCore", "0.0.12.0")]
+	public enum PowerStatusValues
+	{
+		/// <summary>
+		﻿		/// </summary>
+		[Obsolete("Deprecated according to https://model.mtconnect.org/")]
+		[MtconnectVersionApplicability(MtconnectVersions.V_1_0_1, "https://model.mtconnect.org/", MtconnectVersions.V_1_1_0)]
+		ON,
+		/// <summary>
+		﻿		/// </summary>
+		[Obsolete("Deprecated according to https://model.mtconnect.org/")]
+		[MtconnectVersionApplicability(MtconnectVersions.V_1_0_1, "https://model.mtconnect.org/", MtconnectVersions.V_1_1_0)]
+		OFF,
+	}
 }

--- a/MtconnectCore/Standard/Contracts/Enums/Streams/ProcessStateValues.cs
+++ b/MtconnectCore/Standard/Contracts/Enums/Streams/ProcessStateValues.cs
@@ -1,0 +1,45 @@
+using System;
+using System.CodeDom.Compiler;
+using MtconnectCore.Standard.Contracts.Attributes;
+
+namespace MtconnectCore.Standard.Contracts.Enums.Streams
+{
+	/// <summary>
+	/// View in the MTConnect Model browser <seealso href="https://model.mtconnect.org/#Enumeration__">model.mtconnect.org</seealso>
+	﻿	/// </summary>
+	[MtconnectVersionApplicability(MtconnectVersions.V_1_8_0, "https://model.mtconnect.org/")]
+	[GeneratedCode("MtconnectTranspiler.Sinks.MtconnectCore", "0.0.12.0")]
+	public enum ProcessStateValues
+	{
+		/// <summary>
+		﻿/// device is preparing to execute the process occurrence.
+		/// </summary>
+		[MtconnectVersionApplicability(MtconnectVersions.V_1_8_0, "https://model.mtconnect.org/")]
+		INITIALIZING,
+		/// <summary>
+		﻿/// process occurrence is ready to be executed.
+		/// </summary>
+		[MtconnectVersionApplicability(MtconnectVersions.V_1_8_0, "https://model.mtconnect.org/")]
+		READY,
+		/// <summary>
+		﻿/// process occurrence is actively executing.
+		/// </summary>
+		[MtconnectVersionApplicability(MtconnectVersions.V_1_8_0, "https://model.mtconnect.org/")]
+		ACTIVE,
+		/// <summary>
+		﻿/// process occurrence is now finished.
+		/// </summary>
+		[MtconnectVersionApplicability(MtconnectVersions.V_1_8_0, "https://model.mtconnect.org/")]
+		COMPLETE,
+		/// <summary>
+		﻿/// process occurrence has been stopped and may be resumed.
+		/// </summary>
+		[MtconnectVersionApplicability(MtconnectVersions.V_1_8_0, "https://model.mtconnect.org/")]
+		INTERRUPTED,
+		/// <summary>
+		﻿/// process occurrence has come to a premature end and cannot be resumed.
+		/// </summary>
+		[MtconnectVersionApplicability(MtconnectVersions.V_1_8_0, "https://model.mtconnect.org/")]
+		ABORTED,
+	}
+}

--- a/MtconnectCore/Standard/Contracts/Enums/Streams/ProgramEditValues.cs
+++ b/MtconnectCore/Standard/Contracts/Enums/Streams/ProgramEditValues.cs
@@ -1,28 +1,30 @@
-﻿using MtconnectCore.Standard.Contracts.Attributes;
-using MtconnectCore.Standard.Contracts.Enums.Devices.DataItemTypes;
+using System;
+using System.CodeDom.Compiler;
+using MtconnectCore.Standard.Contracts.Attributes;
 
 namespace MtconnectCore.Standard.Contracts.Enums.Streams
 {
-    /// <summary>
-    /// Available values for EVENT element <see cref="EventTypes.PROGRAM_EDIT"/>
-    /// </summary>
-    [MtconnectVersionApplicability(MtconnectVersions.V_1_3_0, "Part 3 Section 3.10.3")]
-    public enum ProgramEditValues
-    {
-        /// <summary>
-        /// A program is currently being edited.
-        /// </summary>
-        [MtconnectVersionApplicability(MtconnectVersions.V_1_3_0, "Part 3 Section 3.10.3")]
-        ACTIVE,
-        /// <summary>
-        /// The controller is capable of editing a program, but it is not  currently editing a program.
-        /// </summary>
-        [MtconnectVersionApplicability(MtconnectVersions.V_1_3_0, "Part 3 Section 3.10.3")]
-        READY,
-        /// <summary>
-        /// The controller is in a state where it cannot edit a program.
-        /// </summary>
-        [MtconnectVersionApplicability(MtconnectVersions.V_1_3_0, "Part 3 Section 3.10.3")]
-        NOT_READY
-    }
+	/// <summary>
+	/// View in the MTConnect Model browser <seealso href="https://model.mtconnect.org/#Enumeration__">model.mtconnect.org</seealso>
+	﻿	/// </summary>
+	[MtconnectVersionApplicability(MtconnectVersions.V_1_3_0, "https://model.mtconnect.org/")]
+	[GeneratedCode("MtconnectTranspiler.Sinks.MtconnectCore", "0.0.12.0")]
+	public enum ProgramEditValues
+	{
+		/// <summary>
+		﻿/// <see cref="Controller">Controller</see> is in the program edit mode.
+		/// </summary>
+		[MtconnectVersionApplicability(MtconnectVersions.V_1_3_0, "https://model.mtconnect.org/")]
+		ACTIVE,
+		/// <summary>
+		﻿/// <see cref="Controller">Controller</see> is capable of entering the program edit mode and no function is inhibiting a change to that mode.
+		/// </summary>
+		[MtconnectVersionApplicability(MtconnectVersions.V_1_3_0, "https://model.mtconnect.org/")]
+		READY,
+		/// <summary>
+		﻿/// <see cref="Controller">Controller</see> is being inhibited by a function from entering the program edit mode.
+		/// </summary>
+		[MtconnectVersionApplicability(MtconnectVersions.V_1_3_0, "https://model.mtconnect.org/")]
+		NOT_READY,
+	}
 }

--- a/MtconnectCore/Standard/Contracts/Enums/Streams/ProgramLocationTypeValues.cs
+++ b/MtconnectCore/Standard/Contracts/Enums/Streams/ProgramLocationTypeValues.cs
@@ -1,23 +1,25 @@
-﻿using MtconnectCore.Standard.Contracts.Attributes;
-using MtconnectCore.Standard.Contracts.Enums.Devices.DataItemTypes;
+using System;
+using System.CodeDom.Compiler;
+using MtconnectCore.Standard.Contracts.Attributes;
 
 namespace MtconnectCore.Standard.Contracts.Enums.Streams
 {
-    /// <summary>
-    /// Available values for EVENT element <see cref="EventTypes.PROGRAM_LOCATION_TYPE"/>
-    /// </summary>
-    [MtconnectVersionApplicability(MtconnectVersions.V_1_5_0, "Part 2 Section 6.2")]
-    public enum ProgramLocationTypeValues
-    {
-        /// <summary>
-        /// Managed by the controller.
-        /// </summary>
-        [MtconnectVersionApplicability(MtconnectVersions.V_1_5_0, "Part 2 Section 6.2")]
-        LOCAL,
-        /// <summary>
-        /// Not managed by the controller.
-        /// </summary>
-        [MtconnectVersionApplicability(MtconnectVersions.V_1_5_0, "Part 2 Section 6.2")]
-        EXTERNAL
-    }
+	/// <summary>
+	/// View in the MTConnect Model browser <seealso href="https://model.mtconnect.org/#Enumeration__">model.mtconnect.org</seealso>
+	﻿	/// </summary>
+	[MtconnectVersionApplicability(MtconnectVersions.V_1_5_0, "https://model.mtconnect.org/")]
+	[GeneratedCode("MtconnectTranspiler.Sinks.MtconnectCore", "0.0.12.0")]
+	public enum ProgramLocationTypeValues
+	{
+		/// <summary>
+		﻿/// managed by the controller.
+		/// </summary>
+		[MtconnectVersionApplicability(MtconnectVersions.V_1_5_0, "https://model.mtconnect.org/")]
+		LOCAL,
+		/// <summary>
+		﻿/// not managed by the controller.
+		/// </summary>
+		[MtconnectVersionApplicability(MtconnectVersions.V_1_5_0, "https://model.mtconnect.org/")]
+		EXTERNAL,
+	}
 }

--- a/MtconnectCore/Standard/Contracts/Enums/Streams/RotaryModeValues.cs
+++ b/MtconnectCore/Standard/Contracts/Enums/Streams/RotaryModeValues.cs
@@ -1,28 +1,30 @@
-﻿using MtconnectCore.Standard.Contracts.Attributes;
-using MtconnectCore.Standard.Contracts.Enums.Devices.DataItemTypes;
+using System;
+using System.CodeDom.Compiler;
+using MtconnectCore.Standard.Contracts.Attributes;
 
 namespace MtconnectCore.Standard.Contracts.Enums.Streams
 {
-    /// <summary>
-    /// Available values for EVENT element <see cref="EventTypes.ROTARY_MODE"/>
-    /// </summary>
-    [MtconnectVersionApplicability(MtconnectVersions.V_1_1_0, "Part 3 Section 3.10.1")]
-    public enum RotaryModeValues
-    {
-        /// <summary>
-        /// The axis is operating like a spindle and spinning.
-        /// </summary>
-        [MtconnectVersionApplicability(MtconnectVersions.V_1_1_0, "Part 3 Section 3.10.1")]
-        SPINDLE,
-        /// <summary>
-        /// The axis is indexing to a position.
-        /// </summary>
-        [MtconnectVersionApplicability(MtconnectVersions.V_1_1_0, "Part 3 Section 3.10.1")]
-        INDEX,
-        /// <summary>
-        /// The axes is indexing and rotating at a programmed velocity.
-        /// </summary>
-        [MtconnectVersionApplicability(MtconnectVersions.V_1_1_0, "Part 3 Section 3.10.1")]
-        CONTOUR
-    }
+	/// <summary>
+	/// View in the MTConnect Model browser <seealso href="https://model.mtconnect.org/#Enumeration__">model.mtconnect.org</seealso>
+	﻿	/// </summary>
+	[MtconnectVersionApplicability(MtconnectVersions.V_1_1_0, "https://model.mtconnect.org/")]
+	[GeneratedCode("MtconnectTranspiler.Sinks.MtconnectCore", "0.0.12.0")]
+	public enum RotaryModeValues
+	{
+		/// <summary>
+		﻿/// axis is functioning as a spindle.
+		/// </summary>
+		[MtconnectVersionApplicability(MtconnectVersions.V_1_1_0, "https://model.mtconnect.org/")]
+		SPINDLE,
+		/// <summary>
+		﻿/// axis is configured to index.
+		/// </summary>
+		[MtconnectVersionApplicability(MtconnectVersions.V_1_1_0, "https://model.mtconnect.org/")]
+		INDEX,
+		/// <summary>
+		﻿/// position of the axis is being interpolated.
+		/// </summary>
+		[MtconnectVersionApplicability(MtconnectVersions.V_1_1_0, "https://model.mtconnect.org/")]
+		CONTOUR,
+	}
 }

--- a/MtconnectCore/Standard/Contracts/Enums/Streams/SpindleInterlockValues.cs
+++ b/MtconnectCore/Standard/Contracts/Enums/Streams/SpindleInterlockValues.cs
@@ -1,23 +1,25 @@
-﻿using MtconnectCore.Standard.Contracts.Attributes;
-using MtconnectCore.Standard.Contracts.Enums.Devices.DataItemTypes;
+using System;
+using System.CodeDom.Compiler;
+using MtconnectCore.Standard.Contracts.Attributes;
 
 namespace MtconnectCore.Standard.Contracts.Enums.Streams
 {
-    /// <summary>
-    /// Available values for EVENT element <see cref="EventTypes.SPINDLE_INTERLOCK"/>
-    /// </summary>
-    [MtconnectVersionApplicability(MtconnectVersions.V_1_3_0, "Part 3 Section 3.10.3")]
-    public enum SpindleInterlockValues
-    {
-        /// <summary>
-        /// The spindle cannot be operated.
-        /// </summary>
-        [MtconnectVersionApplicability(MtconnectVersions.V_1_3_0, "Part 3 Section 3.10.3")]
-        ACTIVE,
-        /// <summary>
-        /// The spindle can be operated.
-        /// </summary>
-        [MtconnectVersionApplicability(MtconnectVersions.V_1_3_0, "Part 3 Section 3.10.3")]
-        INACTIVE
-    }
+	/// <summary>
+	/// View in the MTConnect Model browser <seealso href="https://model.mtconnect.org/#Enumeration__">model.mtconnect.org</seealso>
+	﻿	/// </summary>
+	[MtconnectVersionApplicability(MtconnectVersions.V_1_3_0, "https://model.mtconnect.org/")]
+	[GeneratedCode("MtconnectTranspiler.Sinks.MtconnectCore", "0.0.12.0")]
+	public enum SpindleInterlockValues
+	{
+		/// <summary>
+		﻿/// power has been removed and the spindle cannot be operated.
+		/// </summary>
+		[MtconnectVersionApplicability(MtconnectVersions.V_1_3_0, "https://model.mtconnect.org/")]
+		ACTIVE,
+		/// <summary>
+		﻿/// spindle has not been deactivated.
+		/// </summary>
+		[MtconnectVersionApplicability(MtconnectVersions.V_1_3_0, "https://model.mtconnect.org/")]
+		INACTIVE,
+	}
 }

--- a/MtconnectCore/Standard/Contracts/Enums/Streams/ValveStateValues.cs
+++ b/MtconnectCore/Standard/Contracts/Enums/Streams/ValveStateValues.cs
@@ -1,0 +1,35 @@
+using System;
+using System.CodeDom.Compiler;
+using MtconnectCore.Standard.Contracts.Attributes;
+
+namespace MtconnectCore.Standard.Contracts.Enums.Streams
+{
+	/// <summary>
+	/// View in the MTConnect Model browser <seealso href="https://model.mtconnect.org/#Enumeration__">model.mtconnect.org</seealso>
+	﻿	/// </summary>
+	[MtconnectVersionApplicability(MtconnectVersions.V_1_8_0, "https://model.mtconnect.org/")]
+	[GeneratedCode("MtconnectTranspiler.Sinks.MtconnectCore", "0.0.12.0")]
+	public enum ValveStateValues
+	{
+		/// <summary>
+		﻿/// <see cref="ValveState">ValveState</see> where flow is allowed and the aperture is static.  > Note: For a binary value, <c>OPEN</c> indicates the valve has the maximum possible aperture.
+		/// </summary>
+		[MtconnectVersionApplicability(MtconnectVersions.V_1_8_0, "https://model.mtconnect.org/")]
+		OPEN,
+		/// <summary>
+		﻿/// valve is transitioning from a <c>CLOSED</c> state to an <c>OPEN</c> state.
+		/// </summary>
+		[MtconnectVersionApplicability(MtconnectVersions.V_1_8_0, "https://model.mtconnect.org/")]
+		OPENING,
+		/// <summary>
+		﻿/// <see cref="ValveState">ValveState</see> where flow is not possible, the aperture is static, and the valve is completely shut.
+		/// </summary>
+		[MtconnectVersionApplicability(MtconnectVersions.V_1_8_0, "https://model.mtconnect.org/")]
+		CLOSED,
+		/// <summary>
+		﻿/// valve is transitioning from an <c>OPEN</c> state to a <c>CLOSED</c> state.
+		/// </summary>
+		[MtconnectVersionApplicability(MtconnectVersions.V_1_8_0, "https://model.mtconnect.org/")]
+		CLOSING,
+	}
+}

--- a/MtconnectCore/Standard/Contracts/Enums/Streams/WaitStateValues.cs
+++ b/MtconnectCore/Standard/Contracts/Enums/Streams/WaitStateValues.cs
@@ -1,68 +1,70 @@
-﻿using MtconnectCore.Standard.Contracts.Attributes;
-using MtconnectCore.Standard.Contracts.Enums.Devices.DataItemTypes;
+using System;
+using System.CodeDom.Compiler;
+using MtconnectCore.Standard.Contracts.Attributes;
 
 namespace MtconnectCore.Standard.Contracts.Enums.Streams
 {
-    /// <summary>
-    /// Available values for EVENT element <see cref="EventTypes.WAIT_STATE"/>
-    /// </summary>
-    [MtconnectVersionApplicability(MtconnectVersions.V_1_5_0, "Part 2 Section 6.2")]
-    public enum WaitStateValues
-    {
-        /// <summary>
-        /// An indication that execution is waiting while the equipment is powering up and is not currently available to begin producing parts or products.
-        /// </summary>
-        [MtconnectVersionApplicability(MtconnectVersions.V_1_5_0, "Part 2 Section 6.2")]
-        POWERING_UP,
-        /// <summary>
-        /// An indication that the execution is waiting while the equipment is powering down but has not fully reached a stopped state.
-        /// </summary>
-        [MtconnectVersionApplicability(MtconnectVersions.V_1_5_0, "Part 2 Section 6.2")]
-        POWERING_DOWN,
-        /// <summary>
-        /// An indication that the execution is waiting while one or more discrete workpieces are being loaded.
-        /// </summary>
-        [MtconnectVersionApplicability(MtconnectVersions.V_1_5_0, "Part 2 Section 6.2")]
-        PART_LOAD,
-        /// <summary>
-        /// An indication that the execution is waiting while one or more discrete workpieces are being unloaded.
-        /// </summary>
-        [MtconnectVersionApplicability(MtconnectVersions.V_1_5_0, "Part 2 Section 6.2")]
-        PART_UNLOAD,
-        /// <summary>
-        /// An indication that the execution is waiting while a tool or tooling is being loaded.
-        /// </summary>
-        [MtconnectVersionApplicability(MtconnectVersions.V_1_5_0, "Part 2 Section 6.2")]
-        TOOL_LOAD,
-        /// <summary>
-        /// An indication that the execution is waiting while a tool or tooling is being unloaded.
-        /// </summary>
-        [MtconnectVersionApplicability(MtconnectVersions.V_1_5_0, "Part 2 Section 6.2")]
-        TOOL_UNLOAD,
-        /// <summary>
-        /// An indication that the execution is waiting while bulk material or the container for bulk material used in the production process is being loaded. Bulk material includes those materials from which multiple workpieces may be created.
-        /// </summary>
-        [MtconnectVersionApplicability(MtconnectVersions.V_1_5_0, "Part 2 Section 6.2")]
-        MATERIAL_LOAD,
-        /// <summary>
-        /// An indication that the execution is waiting while bulk material or the container for bulk material used in the production process is being unloaded. Bulk material includes those materials from which multiple workpieces may be created.
-        /// </summary>
-        [MtconnectVersionApplicability(MtconnectVersions.V_1_5_0, "Part 2 Section 6.2")]
-        MATERIAL_UNLOAD,
-        /// <summary>
-        /// An indication that the execution is waiting while another process is completed before the execution can resume.
-        /// </summary>
-        [MtconnectVersionApplicability(MtconnectVersions.V_1_5_0, "Part 2 Section 6.2")]
-        SECONDARY_PROCESS,
-        /// <summary>
-        /// An indication that the execution is waiting while the equipment is pausing but the piece of equipment has not yet reached a fully paused state.
-        /// </summary>
-        [MtconnectVersionApplicability(MtconnectVersions.V_1_5_0, "Part 2 Section 6.2")]
-        PAUSING,
-        /// <summary>
-        /// An indication that the execution is waiting while the equipment is resuming the production cycle but has not yet resumed execution.
-        /// </summary>
-        [MtconnectVersionApplicability(MtconnectVersions.V_1_5_0, "Part 2 Section 6.2")]
-        RESUMING
-    }
+	/// <summary>
+	/// View in the MTConnect Model browser <seealso href="https://model.mtconnect.org/#Enumeration__">model.mtconnect.org</seealso>
+	﻿	/// </summary>
+	[MtconnectVersionApplicability(MtconnectVersions.V_1_5_0, "https://model.mtconnect.org/")]
+	[GeneratedCode("MtconnectTranspiler.Sinks.MtconnectCore", "0.0.12.0")]
+	public enum WaitStateValues
+	{
+		/// <summary>
+		﻿/// execution is waiting while the equipment is powering up and is not currently available to begin producing parts or products.
+		/// </summary>
+		[MtconnectVersionApplicability(MtconnectVersions.V_1_5_0, "https://model.mtconnect.org/")]
+		POWERING_UP,
+		/// <summary>
+		﻿/// execution is waiting while the equipment is powering down but has not fully reached a stopped state.
+		/// </summary>
+		[MtconnectVersionApplicability(MtconnectVersions.V_1_5_0, "https://model.mtconnect.org/")]
+		POWERING_DOWN,
+		/// <summary>
+		﻿/// execution is waiting while one or more discrete workpieces are being loaded.
+		/// </summary>
+		[MtconnectVersionApplicability(MtconnectVersions.V_1_5_0, "https://model.mtconnect.org/")]
+		PART_LOAD,
+		/// <summary>
+		﻿/// execution is waiting while one or more discrete workpieces are being unloaded.
+		/// </summary>
+		[MtconnectVersionApplicability(MtconnectVersions.V_1_5_0, "https://model.mtconnect.org/")]
+		PART_UNLOAD,
+		/// <summary>
+		﻿/// execution is waiting while a tool or tooling is being loaded.
+		/// </summary>
+		[MtconnectVersionApplicability(MtconnectVersions.V_1_5_0, "https://model.mtconnect.org/")]
+		TOOL_LOAD,
+		/// <summary>
+		﻿/// execution is waiting while a tool or tooling is being unloaded.
+		/// </summary>
+		[MtconnectVersionApplicability(MtconnectVersions.V_1_5_0, "https://model.mtconnect.org/")]
+		TOOL_UNLOAD,
+		/// <summary>
+		﻿/// execution is waiting while material is being loaded.
+		/// </summary>
+		[MtconnectVersionApplicability(MtconnectVersions.V_1_5_0, "https://model.mtconnect.org/")]
+		MATERIAL_LOAD,
+		/// <summary>
+		﻿/// execution is waiting while material is being unloaded.
+		/// </summary>
+		[MtconnectVersionApplicability(MtconnectVersions.V_1_5_0, "https://model.mtconnect.org/")]
+		MATERIAL_UNLOAD,
+		/// <summary>
+		﻿/// execution is waiting while another process is completed before the execution can resume.
+		/// </summary>
+		[MtconnectVersionApplicability(MtconnectVersions.V_1_5_0, "https://model.mtconnect.org/")]
+		SECONDARY_PROCESS,
+		/// <summary>
+		﻿/// execution is waiting while the equipment is pausing but the piece of equipment has not yet reached a fully paused state.
+		/// </summary>
+		[MtconnectVersionApplicability(MtconnectVersions.V_1_5_0, "https://model.mtconnect.org/")]
+		PAUSING,
+		/// <summary>
+		﻿/// execution is waiting while the equipment is resuming the production cycle but has not yet resumed execution.
+		/// </summary>
+		[MtconnectVersionApplicability(MtconnectVersions.V_1_5_0, "https://model.mtconnect.org/")]
+		RESUMING,
+	}
 }

--- a/MtconnectCore/Standard/Documents/Streams/Condition.cs
+++ b/MtconnectCore/Standard/Documents/Streams/Condition.cs
@@ -62,14 +62,6 @@ namespace MtconnectCore.Standard.Documents.Streams
         public string Statistic { get; set; }
 
         /// <summary>
-        /// Collected from the subType attribute. Refer to Part 3 Streams - 5.8.3
-        /// 
-        /// Occurance: 0..1
-        /// </summary>
-        [MtconnectNodeAttribute(ConditionAttributes.SUB_TYPE)]
-        public string SubType { get; set; }
-
-        /// <summary>
         /// Collected from the compositionId attribute. Refer to Part 3 Streams - 5.8.3
         /// 
         /// Occurance: 0..1
@@ -137,7 +129,7 @@ namespace MtconnectCore.Standard.Documents.Streams
 
         [MtconnectVersionApplicability(MtconnectVersions.V_1_0_1, "Part 3 Section 3.8")]
         protected override bool validateNode(out ICollection<MtconnectValidationException> validationErrors)
-            => validateNode<ConditionElements>(Contracts.Enums.Devices.CategoryTypes.CONDITION, out validationErrors);
+            => validateNode<MtconnectCore.Standard.Contracts.Enums.Devices.DataItemTypes.ConditionTypes>(Contracts.Enums.Devices.CategoryTypes.CONDITION, out validationErrors);
 
         protected override bool validateValue(out ICollection<MtconnectValidationException> validationErrors) => throw new NotImplementedException();
     }

--- a/MtconnectCore/Standard/Documents/Streams/DataItem.cs
+++ b/MtconnectCore/Standard/Documents/Streams/DataItem.cs
@@ -5,7 +5,9 @@ using MtconnectCore.Standard.Contracts.Enums.Streams.Attributes;
 using MtconnectCore.Standard.Contracts.Errors;
 using System;
 using System.Collections.Generic;
+using System.Data;
 using System.Linq;
+using System.Reflection;
 using System.Xml;
 
 namespace MtconnectCore.Standard.Documents.Streams
@@ -20,6 +22,10 @@ namespace MtconnectCore.Standard.Documents.Streams
         /// </summary>
         [MtconnectNodeAttribute(SampleAttributes.DATA_ITEM_ID)]
         public string DataItemId { get; set; }
+
+        /// <inheritdoc cref="SampleAttributes.SUB_TYPE"/>
+        [MtconnectNodeAttribute(SampleAttributes.SUB_TYPE)]
+        public string SubType { get; set; }
 
         /// <summary>
         /// Collected from the timestamp attribute. Refer to Part 3 Streams - 5.3.2, 5.5.2, 5.8.3
@@ -140,46 +146,77 @@ namespace MtconnectCore.Standard.Documents.Streams
 
         protected bool validateNodeInStandard<T>(MtconnectCore.Standard.Contracts.Enums.Devices.CategoryTypes categoryType, out ICollection<MtconnectValidationException> validationErrors) where T : Enum
         {
-            validationErrors = new List<MtconnectValidationException>();
-            if (!string.IsNullOrEmpty(this.SourceNode.LocalName))
-            {
-                if (!EnumHelper.Contains<T>(this.SourceNode.LocalName))
-                {
-                    validationErrors.Add(new MtconnectValidationException(
-                        ValidationSeverity.ERROR,
-                        $"{categoryType.ToString()} '{this.SourceNode.LocalName}' is not defined in the MTConnect Standard in version '{MtconnectVersion}' as a valid {categoryType.ToString()} type.",
-                        SourceNode));
-                }
-                else if (!EnumHelper.ValidateToVersion<T>(this.SourceNode.LocalName, MtconnectVersion.GetValueOrDefault()) && !EnumHelper.ValidateToVersion<T>(this.SourceNode.LocalName, MtconnectVersion.GetValueOrDefault()))
-                {
-                    validationErrors.Add(new MtconnectValidationException(
-                        ValidationSeverity.WARNING,
-                        $"{categoryType.ToString()} '{this.SourceNode.LocalName}' is not valid in version '{MtconnectVersion}' of the MTConnect Standard as a valid {categoryType.ToString()} type.",
-                        SourceNode));
-                }
-            }
-            return !validationErrors.Any(o => o.Severity == ValidationSeverity.ERROR);
-        }
+            //validationErrors = new List<MtconnectValidationException>();
+            //if (!string.IsNullOrEmpty(this.SourceNode.LocalName))
+            //{
+            //    if (!EnumHelper.Contains<T>(this.SourceNode.LocalName))
+            //    {
+            //        validationErrors.Add(new MtconnectValidationException(
+            //            ValidationSeverity.ERROR,
+            //            $"{categoryType.ToString()} '{this.SourceNode.LocalName}' is not defined in the MTConnect Standard in version '{MtconnectVersion}' as a valid {categoryType.ToString()} type.",
+            //            SourceNode));
+            //    }
+            //    else if (!EnumHelper.ValidateToVersion<T>(this.SourceNode.LocalName, MtconnectVersion.GetValueOrDefault()) && !EnumHelper.ValidateToVersion<T>(this.SourceNode.LocalName, MtconnectVersion.GetValueOrDefault()))
+            //    {
+            //        validationErrors.Add(new MtconnectValidationException(
+            //            ValidationSeverity.WARNING,
+            //            $"{categoryType.ToString()} '{this.SourceNode.LocalName}' is not valid in version '{MtconnectVersion}' of the MTConnect Standard as a valid {categoryType.ToString()} type.",
+            //            SourceNode));
+            //    }
+            //}
+            //return !validationErrors.Any(o => o.Severity == ValidationSeverity.ERROR);
 
-        /// <summary>
-        /// Attempts to validate a DataItem subType value according the specified type (<typeparamref name="T"/>).
-        /// </summary>
-        /// <typeparam name="T">Reference to the <see cref="Enum"/> containing appropriate subType values.</typeparam>
-        /// <param name="subType">Reference to the subType provided in the Response Document.</param>
-        /// <param name="validationError">Output of the error found in validating the subType.</param>
-        /// <returns>Flag for whether or not the validation passed.</returns>
-        protected bool tryValidateSubType<T>(string subType, out MtconnectValidationException validationError) where T : Enum
-        {
-            validationError = null;
-            if (!EnumHelper.Contains<T>(subType))
+            bool isValidType = true, isValidSubType = true;
+            validationErrors = new List<MtconnectValidationException>();
+
+            // Validate the observational type
+            if (!EnumHelper.Contains<T>(SourceNode.LocalName))
             {
-                validationError = new MtconnectValidationException(
+                validationErrors.Add(new MtconnectValidationException(
                     ValidationSeverity.ERROR,
-                    $"{SourceNode.LocalName} MUST be one of the following subTypes: {EnumHelper.ToListString<T>(", ", "'", "'")}",
-                    SourceNode);
-                return true;
+                    $"DataItem type of '{SourceNode.LocalName}' is not defined in the MTConnect Standard for category '{categoryType}' in version '{MtconnectVersion}'.",
+                    SourceNode));
+                isValidType = false;
             }
-            return false;
+            else if (!EnumHelper.ValidateToVersion<T>(SourceNode.LocalName, MtconnectVersion.GetValueOrDefault()))
+            {
+                validationErrors.Add(new MtconnectValidationException(
+                    ValidationSeverity.WARNING,
+                    $"DataItem type of '{SourceNode.LocalName}' is not valid for category '{categoryType}' in version '{MtconnectVersion}' of the MTConnect Standard.",
+                    SourceNode));
+                isValidType = false;
+            }
+
+            if (isValidType)
+            {
+                // Get the Enum and look for an attribute pointing to the SubType enum
+                Type enumType = typeof(T);
+                MemberInfo[] typeValueInfos = enumType.GetMember(SourceNode.LocalName);
+                var valueInfo = typeValueInfos.FirstOrDefault(o => o.DeclaringType == enumType);
+                var obsSubType = valueInfo.GetCustomAttribute<ObservationalSubTypeAttribute>();
+                // Validate the observational sub-type
+                if (obsSubType != null)
+                {
+                    if (!EnumHelper.Contains(obsSubType.SubTypeEnum, SubType))
+                    {
+                        validationErrors.Add(new MtconnectValidationException(
+                        ValidationSeverity.ERROR,
+                            $"DataItem subType of '{SubType}' is not defined in the MTConnect Standard for category '{categoryType}' and type '{SourceNode.LocalName}' in version '{MtconnectVersion}'.",
+                            SourceNode));
+                        isValidSubType = false;
+                    }
+                    else if (!EnumHelper.ValidateToVersion(obsSubType.SubTypeEnum, SubType, MtconnectVersion.GetValueOrDefault()))
+                    {
+                        validationErrors.Add(new MtconnectValidationException(
+                        ValidationSeverity.WARNING,
+                            $"DataItem subType of '{SubType}' is not valid for category '{categoryType}' and type '{SourceNode.LocalName}' in version '{MtconnectVersion}' of the MTConnect Standard.",
+                            SourceNode));
+                        isValidSubType = false;
+                    }
+                }
+            }
+
+            return !validationErrors.Any(o => o.Severity == ValidationSeverity.ERROR);
         }
     }
 }

--- a/MtconnectCore/Standard/Documents/Streams/DataItem.cs
+++ b/MtconnectCore/Standard/Documents/Streams/DataItem.cs
@@ -191,13 +191,20 @@ namespace MtconnectCore.Standard.Documents.Streams
             {
                 // Get the Enum and look for an attribute pointing to the SubType enum
                 Type enumType = typeof(T);
-                MemberInfo[] typeValueInfos = enumType.GetMember(SourceNode.LocalName);
+                MemberInfo[] typeValueInfos = enumType.GetMember(EnumHelper.Enumify(SourceNode.LocalName));
                 var valueInfo = typeValueInfos.FirstOrDefault(o => o.DeclaringType == enumType);
-                var obsSubType = valueInfo.GetCustomAttribute<ObservationalSubTypeAttribute>();
+                var obsSubType = valueInfo?.GetCustomAttribute<ObservationalSubTypeAttribute>();
                 // Validate the observational sub-type
                 if (obsSubType != null)
                 {
-                    if (!EnumHelper.Contains(obsSubType.SubTypeEnum, SubType))
+                    if (string.IsNullOrEmpty(SubType))
+                    {
+                        validationErrors.Add(new MtconnectValidationException(
+                            ValidationSeverity.ERROR,
+                            $"DataItem type '{SourceNode.LocalName}' is missing a subType",
+                            SourceNode));
+                        isValidSubType = false;
+                    } else if (!EnumHelper.Contains(obsSubType.SubTypeEnum, SubType))
                     {
                         validationErrors.Add(new MtconnectValidationException(
                         ValidationSeverity.ERROR,

--- a/MtconnectCore/Standard/Documents/Streams/Event.cs
+++ b/MtconnectCore/Standard/Documents/Streams/Event.cs
@@ -74,6 +74,23 @@ namespace MtconnectCore.Standard.Documents.Streams
         protected override bool validateNode(out ICollection<MtconnectValidationException> validationErrors)
             => validateNode<MtconnectCore.Standard.Contracts.Enums.Devices.DataItemTypes.EventTypes>(Contracts.Enums.Devices.CategoryTypes.EVENT, out validationErrors);
 
-        protected override bool validateValue(out ICollection<MtconnectValidationException> validationErrors) => throw new System.NotImplementedException();
+        [MtconnectVersionApplicability(MtconnectVersions.V_1_0_1, "")]
+        protected override bool validateValue(out ICollection<MtconnectValidationException> validationErrors)
+        {
+            validationErrors = new List<MtconnectValidationException>();
+
+            if (string.IsNullOrEmpty(Value))
+            {
+                validationErrors.Add(new MtconnectValidationException(
+                    ValidationSeverity.ERROR,
+                    $"DataItem MUST include a value.",
+                    SourceNode));
+            } else if (true)
+            {
+
+            }
+
+            return !validationErrors.Any(o => o.Severity == ValidationSeverity.ERROR);
+        }
     }
 }

--- a/MtconnectCore/Standard/Documents/Streams/Event.cs
+++ b/MtconnectCore/Standard/Documents/Streams/Event.cs
@@ -1,11 +1,13 @@
 ﻿using MtconnectCore.Standard.Contracts;
 using MtconnectCore.Standard.Contracts.Attributes;
 using MtconnectCore.Standard.Contracts.Enums;
-using MtconnectCore.Standard.Contracts.Enums.Streams.Attributes;
+using MtcStreams = MtconnectCore.Standard.Contracts.Enums.Streams.Attributes;
 using MtconnectCore.Standard.Contracts.Enums.Streams.Elements;
 using MtconnectCore.Standard.Contracts.Errors;
+using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using System.Xml;
 
 namespace MtconnectCore.Standard.Documents.Streams
@@ -17,7 +19,7 @@ namespace MtconnectCore.Standard.Documents.Streams
         /// 
         /// Occurance: 0..1
         /// </summary>
-        [MtconnectNodeAttribute(EventAttributes.NAME)]
+        [MtconnectNodeAttribute(MtcStreams.EventAttributes.NAME)]
         public string Name { get; set; }
 
         /// <summary>
@@ -25,15 +27,15 @@ namespace MtconnectCore.Standard.Documents.Streams
         /// 
         /// Occurance: 0..1
         /// </summary>
-        [MtconnectNodeAttribute(EventAttributes.RESET_TRIGGERED)]
-        public ResetTriggers? ResetTriggered { get; set; }
+        [MtconnectNodeAttribute(MtcStreams.EventAttributes.RESET_TRIGGERED)]
+        public MtcStreams.ResetTriggers? ResetTriggered { get; set; }
 
         /// <summary>
         /// Collected from the compositionId attribute. Refer to Part 3 Streams - 5.5.2
         /// 
         /// Occurance: 0..1
         /// </summary>
-        [MtconnectNodeAttribute(EventAttributes.COMPOSITION_ID)]
+        [MtconnectNodeAttribute(MtcStreams.EventAttributes.COMPOSITION_ID)]
         public string CompositionId { get; set; }
 
         /// <summary>
@@ -85,9 +87,19 @@ namespace MtconnectCore.Standard.Documents.Streams
                     ValidationSeverity.ERROR,
                     $"DataItem MUST include a value.",
                     SourceNode));
-            } else if (true)
+            } else if (Enum.TryParse<MtconnectCore.Standard.Contracts.Enums.Devices.DataItemTypes.EventTypes>(SourceNode.LocalName, out MtconnectCore.Standard.Contracts.Enums.Devices.DataItemTypes.EventTypes type))
             {
-
+                var observationalValue = type.GetType().GetCustomAttribute<ObservationalValueAttribute>();
+                if (observationalValue != null)
+                {
+                    if (!EnumHelper.Contains(observationalValue.ValueEnum, Value))
+                    {
+                        validationErrors.Add(new MtconnectValidationException(
+                            ValidationSeverity.ERROR,
+                            $"DataItem value does not match expected values for EVENT type '{SourceNode.LocalName}'",
+                            SourceNode));
+                    }
+                }
             }
 
             return !validationErrors.Any(o => o.Severity == ValidationSeverity.ERROR);

--- a/MtconnectCore/Standard/Documents/Streams/Event.cs
+++ b/MtconnectCore/Standard/Documents/Streams/Event.cs
@@ -13,14 +13,6 @@ namespace MtconnectCore.Standard.Documents.Streams
     public class Event : DataItem
     {
         /// <summary>
-        /// Collected from the subType attribute. Refer to Part 3 Streams - 5.5.2
-        /// 
-        /// Occurance: 0..1
-        /// </summary>
-        [MtconnectNodeAttribute(EventAttributes.SUB_TYPE)]
-        public string SubType { get; set; }
-
-        /// <summary>
         /// Collected from the name attribute. Refer to Part 3 Streams - 5.5.2
         /// 
         /// Occurance: 0..1

--- a/MtconnectCore/Standard/Documents/Streams/Sample.cs
+++ b/MtconnectCore/Standard/Documents/Streams/Sample.cs
@@ -16,14 +16,6 @@ namespace MtconnectCore.Standard.Documents.Streams
     public class Sample : DataItem
     {
         /// <summary>
-        /// Collected from the subType attribute. Refer to Part 3 Streams - 5.3.2
-        /// 
-        /// Occurance: 0..1
-        /// </summary>
-        [MtconnectNodeAttribute(SampleAttributes.SUB_TYPE)]
-        public string SubType { get; set; }
-
-        /// <summary>
         /// Collected from the name attribute. Refer to Part 3 Streams - 5.3.2
         /// 
         /// Occurance: 0..1
@@ -141,281 +133,40 @@ namespace MtconnectCore.Standard.Documents.Streams
 
             if (Enum.TryParse<MtconnectCore.Standard.Contracts.Enums.Devices.DataItemTypes.SampleTypes>(SourceNode.LocalName, out MtconnectCore.Standard.Contracts.Enums.Devices.DataItemTypes.SampleTypes type))
             {
-                // TODO: Implement checks for subType more dynamically using the Transpiler
-                //switch (type)
-                //{
-                //    case Contracts.Enums.Devices.DataItemTypes.SampleTypes.ACCELERATION:
-                //        break;
-                //    case Contracts.Enums.Devices.DataItemTypes.SampleTypes.ACCUMULATED_TIME:
-                //        break;
-                //    case Contracts.Enums.Devices.DataItemTypes.SampleTypes.ANGULAR_ACCELERATION:
-                //        break;
-                //    case Contracts.Enums.Devices.DataItemTypes.SampleTypes.ANGULAR_VELOCITY:
-                //        break;
-                //    case Contracts.Enums.Devices.DataItemTypes.SampleTypes.AMPERAGE:
-                //        break;
-                //    case Contracts.Enums.Devices.DataItemTypes.SampleTypes.AMPERAGE_AC:
-                //        if (!tryValidateSubType<AmperageAcSubTypes>(SubType, out MtconnectValidationException amperageAcSubTypeError))
-                //        {
-                //            validationErrors.Add(amperageAcSubTypeError);
-                //        }
-                //        break;
-                //    case Contracts.Enums.Devices.DataItemTypes.SampleTypes.AMPERAGE_DC:
-                //        if (!tryValidateSubType<AmperageDcSubTypes>(SubType, out MtconnectValidationException amperageDcSubTypeError))
-                //        {
-                //            validationErrors.Add(amperageDcSubTypeError);
-                //        }
-                //        break;
-                //    case Contracts.Enums.Devices.DataItemTypes.SampleTypes.ANGLE:
-                //        if (!string.IsNullOrEmpty(SubType) && !tryValidateSubType<AngleSubTypes>(SubType, out MtconnectValidationException angleSubTypeError))
-                //        {
-                //            validationErrors.Add(angleSubTypeError);
-                //        }
-                //        break;
-                //    case Contracts.Enums.Devices.DataItemTypes.SampleTypes.AXIS_FEEDRATE:
-                //        if (!string.IsNullOrEmpty(SubType) && !tryValidateSubType<AxisFeedrateSubTypes>(SubType, out MtconnectValidationException axisFeedrateSubTypeError))
-                //        {
-                //            validationErrors.Add(axisFeedrateSubTypeError);
-                //        }
-                //        break;
-                //    case Contracts.Enums.Devices.DataItemTypes.SampleTypes.CAPACITY_FLUID:
-                //        break;
-                //    case Contracts.Enums.Devices.DataItemTypes.SampleTypes.CAPACITY_SPATIAL:
-                //        break;
-                //    case Contracts.Enums.Devices.DataItemTypes.SampleTypes.CLOCK_TIME:
-                //        var iso8601 = new Regex(@"^(?:[1-9]\d{3}-(?:(?:0[1-9]|1[0-2])-(?:0[1-9]|1\d|2[0-8])|(?:0[13-9]|1[0-2])-(?:29|30)|(?:0[13578]|1[02])-31)|(?:[1-9]\d(?:0[48]|[2468][048]|[13579][26])|(?:[2468][048]|[13579][26])00)-02-29)T(?:[01]\d|2[0-3]):[0-5]\d:[0-5]\d(?:Z|[+-][01]\d:[0-5]\d)$");
-                //        if (!iso8601.IsMatch(Value))
-                //        {
-                //            validationErrors.Add(new MtconnectValidationException(
-                //                ValidationSeverity.ERROR,
-                //                $"ClockTime MUST be reported in W3C ISO 8601 format.",
-                //                SourceNode));
-                //        }
-                //        break;
-                //    case Contracts.Enums.Devices.DataItemTypes.SampleTypes.CONCENTRATION:
-                //        break;
-                //    case Contracts.Enums.Devices.DataItemTypes.SampleTypes.CONDUCTIVITY:
-                //        break;
-                //    case Contracts.Enums.Devices.DataItemTypes.SampleTypes.CUTTING_SPEED:
-                //        if (!string.IsNullOrEmpty(SubType) && !tryValidateSubType<CuttingSpeedSubTypes>(SubType, out MtconnectValidationException cuttingSpeedSubTypeError))
-                //        {
-                //            validationErrors.Add(cuttingSpeedSubTypeError);
-                //        }
-                //        break;
-                //    case Contracts.Enums.Devices.DataItemTypes.SampleTypes.DENSITY:
-                //        break;
-                //    case Contracts.Enums.Devices.DataItemTypes.SampleTypes.DEPOSITION_ACCELERATION_VOLUMETRIC:
-                //        if (!string.IsNullOrEmpty(SubType) && !tryValidateSubType<DepositionAccelerationVolumetricSubTypes>(SubType, out MtconnectValidationException depositionAccelerationVolumetricSubTypeError))
-                //        {
-                //            validationErrors.Add(depositionAccelerationVolumetricSubTypeError);
-                //        }
-                //        break;
-                //    case Contracts.Enums.Devices.DataItemTypes.SampleTypes.DEPOSITION_DENSITY:
-                //        if (!string.IsNullOrEmpty(SubType) && !tryValidateSubType<DepositionDensitySubTypes>(SubType, out MtconnectValidationException depositionDensitySubTypeError))
-                //        {
-                //            validationErrors.Add(depositionDensitySubTypeError);
-                //        }
-                //        break;
-                //    case Contracts.Enums.Devices.DataItemTypes.SampleTypes.DEPOSITION_MASS:
-                //        if (!string.IsNullOrEmpty(SubType) && !tryValidateSubType<DepositionMassSubTypes>(SubType, out MtconnectValidationException depositionMassSubTypeError))
-                //        {
-                //            validationErrors.Add(depositionMassSubTypeError);
-                //        }
-                //        break;
-                //    case Contracts.Enums.Devices.DataItemTypes.SampleTypes.DEPOSITION_RATE_VOLUMETRIC:
-                //        if (!string.IsNullOrEmpty(SubType) && !tryValidateSubType<DepositionRateVolumetricSubTypes>(SubType, out MtconnectValidationException depositionRateVolumetricSubTypeError))
-                //        {
-                //            validationErrors.Add(depositionRateVolumetricSubTypeError);
-                //        }
-                //        break;
-                //    case Contracts.Enums.Devices.DataItemTypes.SampleTypes.DEPOSITION_VOLUME:
-                //        if (!string.IsNullOrEmpty(SubType) && !tryValidateSubType<DepositionVolumeSubTypes>(SubType, out MtconnectValidationException depositionVolumeSubTypeError))
-                //        {
-                //            validationErrors.Add(depositionVolumeSubTypeError);
-                //        }
-                //        break;
-                //    case Contracts.Enums.Devices.DataItemTypes.SampleTypes.DIAMETER:
-                //        break;
-                //    case Contracts.Enums.Devices.DataItemTypes.SampleTypes.DISPLACEMENT:
-                //        break;
-                //    case Contracts.Enums.Devices.DataItemTypes.SampleTypes.ELECTRICAL_ENERGY:
-                //        break;
-                //    case Contracts.Enums.Devices.DataItemTypes.SampleTypes.EQUIPMENT_TIMER:
-                //        if (!string.IsNullOrEmpty(SubType) && !tryValidateSubType<EquipmentTimerSubTypes>(SubType, out MtconnectValidationException equipmentTimerSubTypeError))
-                //        {
-                //            validationErrors.Add(equipmentTimerSubTypeError);
-                //        }
-                //        break;
-                //    case Contracts.Enums.Devices.DataItemTypes.SampleTypes.FILL_LEVEL:
-                //        break;
-                //    case Contracts.Enums.Devices.DataItemTypes.SampleTypes.FLOW:
-                //        break;
-                //    case Contracts.Enums.Devices.DataItemTypes.SampleTypes.FREQUENCY:
-                //        break;
-                //    case Contracts.Enums.Devices.DataItemTypes.SampleTypes.GLOBAL_POSITION:
-                //        break;
-                //    case Contracts.Enums.Devices.DataItemTypes.SampleTypes.HUMIDITY_ABSOLUTE:
-                //        if (!string.IsNullOrEmpty(SubType) && !tryValidateSubType<HumidityAbsoluteSubTypes>(SubType, out MtconnectValidationException humidityAbsoluteSubTypeError))
-                //        {
-                //            validationErrors.Add(humidityAbsoluteSubTypeError);
-                //        }
-                //        break;
-                //    case Contracts.Enums.Devices.DataItemTypes.SampleTypes.HUMIDITY_RELATIVE:
-                //        if (!string.IsNullOrEmpty(SubType) && !tryValidateSubType<HumidityRelativeSubTypes>(SubType, out MtconnectValidationException humidityRelativeSubTypeError))
-                //        {
-                //            validationErrors.Add(humidityRelativeSubTypeError);
-                //        }
-                //        break;
-                //    case Contracts.Enums.Devices.DataItemTypes.SampleTypes.HUMIDITY_SPECIFIC:
-                //        if (!string.IsNullOrEmpty(SubType) && !tryValidateSubType<HumiditySpecificSubTypes>(SubType, out MtconnectValidationException humiditySpecificSubTypeError))
-                //        {
-                //            validationErrors.Add(humiditySpecificSubTypeError);
-                //        }
-                //        break;
-                //    case Contracts.Enums.Devices.DataItemTypes.SampleTypes.LENGTH:
-                //        if (!string.IsNullOrEmpty(SubType) && !tryValidateSubType<LengthSubTypes>(SubType, out MtconnectValidationException lengthSubTypeError))
-                //        {
-                //            validationErrors.Add(lengthSubTypeError);
-                //        }
-                //        break;
-                //    case Contracts.Enums.Devices.DataItemTypes.SampleTypes.LEVEL:
-                //        break;
-                //    case Contracts.Enums.Devices.DataItemTypes.SampleTypes.LINEAR_FORCE:
-                //        break;
-                //    case Contracts.Enums.Devices.DataItemTypes.SampleTypes.LOAD:
-                //        break;
-                //    case Contracts.Enums.Devices.DataItemTypes.SampleTypes.MASS:
-                //        break;
-                //    case Contracts.Enums.Devices.DataItemTypes.SampleTypes.ORIENTATION:
-                //        if (Value.Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries).Length != 3 || Value.Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries).All(o => decimal.TryParse(o, out _)) == false)
-                //        {
-                //            validationErrors.Add(new MtconnectValidationException(
-                //                ValidationSeverity.ERROR,
-                //                $"ORIENTATION value MUST be three space-delimited floating-point numbers.",
-                //                SourceNode));
-                //        }
-                //        break;
-                //    case Contracts.Enums.Devices.DataItemTypes.SampleTypes.PATH_FEEDRATE:
-                //        if (!string.IsNullOrEmpty(SubType) && !tryValidateSubType<PathFeedrateSubTypes>(SubType, out MtconnectValidationException pathFeedrateSubTypeError))
-                //        {
-                //            validationErrors.Add(pathFeedrateSubTypeError);
-                //        }
-                //        break;
-                //    case Contracts.Enums.Devices.DataItemTypes.SampleTypes.PATH_FEEDRATE_PER_REVOLUTION:
-                //        if (!string.IsNullOrEmpty(SubType) && !tryValidateSubType<PathFeedratePerRevolutionSubTypes>(SubType, out MtconnectValidationException pathFeedratePerRevolutionSubTypeError))
-                //        {
-                //            validationErrors.Add(pathFeedratePerRevolutionSubTypeError);
-                //        }
-                //        break;
-                //    case Contracts.Enums.Devices.DataItemTypes.SampleTypes.PATH_POSITION:
-                //        if (!string.IsNullOrEmpty(SubType) && !tryValidateSubType<PathPositionSubTypes>(SubType, out MtconnectValidationException pathPositionSubTypeError))
-                //        {
-                //            validationErrors.Add(pathPositionSubTypeError);
-                //        } else if (!Value.Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries).All(o => decimal.TryParse(o, out _)))
-                //        {
-                //            validationErrors.Add(new MtconnectValidationException(
-                //                ValidationSeverity.ERROR,
-                //                $"PATH_POSITION value MUST be reported as a set of space-delimited floating-point numbers.",
-                //                SourceNode));
-                //        }
-                //        break;
-                //    case Contracts.Enums.Devices.DataItemTypes.SampleTypes.PH:
-                //        break;
-                //    case Contracts.Enums.Devices.DataItemTypes.SampleTypes.POSITION:
-                //        if (!string.IsNullOrEmpty(SubType) && !tryValidateSubType<PositionSubTypes>(SubType, out MtconnectValidationException positionSubTypeError))
-                //        {
-                //            validationErrors.Add(positionSubTypeError);
-                //        }
-                //        break;
-                //    case Contracts.Enums.Devices.DataItemTypes.SampleTypes.POWER_FACTOR:
-                //        break;
-                //    case Contracts.Enums.Devices.DataItemTypes.SampleTypes.PRESSURE:
-                //        break;
-                //    case Contracts.Enums.Devices.DataItemTypes.SampleTypes.PROCESS_TIMER:
-                //        if (!tryValidateSubType<ProcessTimerSubTypes>(SubType, out MtconnectValidationException processTimerSubTypeError))
-                //        {
-                //            validationErrors.Add(processTimerSubTypeError);
-                //        }
-                //        break;
-                //    case Contracts.Enums.Devices.DataItemTypes.SampleTypes.RESISTANCE:
-                //        break;
-                //    case Contracts.Enums.Devices.DataItemTypes.SampleTypes.ROTARY_VELOCITY:
-                //        if (!string.IsNullOrEmpty(SubType) && !tryValidateSubType<RotaryVelocitySubTypes>(SubType, out MtconnectValidationException rotaryVelocityTypeError))
-                //        {
-                //            validationErrors.Add(rotaryVelocityTypeError);
-                //        }
-                //        break;
-                //    case Contracts.Enums.Devices.DataItemTypes.SampleTypes.SOUND_LEVEL:
-                //        if (!string.IsNullOrEmpty(SubType) && !tryValidateSubType<SoundLeveSubTypes>(SubType, out MtconnectValidationException soundLevelTypeError))
-                //        {
-                //            validationErrors.Add(soundLevelTypeError);
-                //        }
-                //        break;
-                //    case Contracts.Enums.Devices.DataItemTypes.SampleTypes.SPINDLE_SPEED:
-                //        break;
-                //    case Contracts.Enums.Devices.DataItemTypes.SampleTypes.STRAIN:
-                //        break;
-                //    case Contracts.Enums.Devices.DataItemTypes.SampleTypes.TEMPERATURE:
-                //        if (!string.IsNullOrEmpty(SubType) && !tryValidateSubType<TemperatureSubTypes>(SubType, out MtconnectValidationException temperatureTypeError))
-                //        {
-                //            validationErrors.Add(temperatureTypeError);
-                //        }
-                //        break;
-                //    case Contracts.Enums.Devices.DataItemTypes.SampleTypes.TENSION:
-                //        break;
-                //    case Contracts.Enums.Devices.DataItemTypes.SampleTypes.TILT:
-                //        break;
-                //    case Contracts.Enums.Devices.DataItemTypes.SampleTypes.TORQUE:
-                //        break;
-                //    case Contracts.Enums.Devices.DataItemTypes.SampleTypes.VELOCITY:
-                //        break;
-                //    case Contracts.Enums.Devices.DataItemTypes.SampleTypes.VISCOSITY:
-                //        break;
-                //    case Contracts.Enums.Devices.DataItemTypes.SampleTypes.VOLTAGE:
-                //        break;
-                //    case Contracts.Enums.Devices.DataItemTypes.SampleTypes.VOLTAGE_AC:
-                //        if (!string.IsNullOrEmpty(SubType) && !tryValidateSubType<VoltageAcSubTypes>(SubType, out MtconnectValidationException voltageAcTypeError))
-                //        {
-                //            validationErrors.Add(voltageAcTypeError);
-                //        }
-                //        break;
-                //    case Contracts.Enums.Devices.DataItemTypes.SampleTypes.VOLTAGE_DC:
-                //        if (!string.IsNullOrEmpty(SubType) && !tryValidateSubType<VoltageDcSubTypes>(SubType, out MtconnectValidationException voltageDcTypeError))
-                //        {
-                //            validationErrors.Add(voltageDcTypeError);
-                //        }
-                //        break;
-                //    case Contracts.Enums.Devices.DataItemTypes.SampleTypes.VOLT_AMPERE:
-                //        break;
-                //    case Contracts.Enums.Devices.DataItemTypes.SampleTypes.VOLT_AMPERE_REACTIVE:
-                //        break;
-                //    case Contracts.Enums.Devices.DataItemTypes.SampleTypes.VOLUME_FLUID:
-                //        if (!string.IsNullOrEmpty(SubType) && !tryValidateSubType<VolumeFluidSubTypes>(SubType, out MtconnectValidationException volumeFluidTypeError))
-                //        {
-                //            validationErrors.Add(volumeFluidTypeError);
-                //        }
-                //        break;
-                //    case Contracts.Enums.Devices.DataItemTypes.SampleTypes.VOLUME_SPATIAL:
-                //        if (!string.IsNullOrEmpty(SubType) && !tryValidateSubType<VolumeSpatialSubTypes>(SubType, out MtconnectValidationException volumeSpatialTypeError))
-                //        {
-                //            validationErrors.Add(volumeSpatialTypeError);
-                //        }
-                //        break;
-                //    case Contracts.Enums.Devices.DataItemTypes.SampleTypes.WATTAGE:
-                //        if (!string.IsNullOrEmpty(SubType) && !tryValidateSubType<WattageSubTypes>(SubType, out MtconnectValidationException wattageTypeError))
-                //        {
-                //            validationErrors.Add(wattageTypeError);
-                //        }
-                //        break;
-                //    case Contracts.Enums.Devices.DataItemTypes.SampleTypes.X_DIMENSION:
-                //        break;
-                //    case Contracts.Enums.Devices.DataItemTypes.SampleTypes.Y_DIMENSION:
-                //        break;
-                //    case Contracts.Enums.Devices.DataItemTypes.SampleTypes.Z_DIMENSION:
-                //        break;
-                //    default:
-                //        break;
-                //}
+                // NOTE: Only validate the VALUE, not the Sub-Type
+                switch (type)
+                {
+                    //case Contracts.Enums.Devices.DataItemTypes.SampleTypes.CLOCK_TIME:
+                    //    var iso8601 = new Regex(@"^(?:[1-9]\d{3}-(?:(?:0[1-9]|1[0-2])-(?:0[1-9]|1\d|2[0-8])|(?:0[13-9]|1[0-2])-(?:29|30)|(?:0[13578]|1[02])-31)|(?:[1-9]\d(?:0[48]|[2468][048]|[13579][26])|(?:[2468][048]|[13579][26])00)-02-29)T(?:[01]\d|2[0-3]):[0-5]\d:[0-5]\d(?:Z|[+-][01]\d:[0-5]\d)$");
+                    //    if (!iso8601.IsMatch(Value))
+                    //    {
+                    //        validationErrors.Add(new MtconnectValidationException(
+                    //            ValidationSeverity.ERROR,
+                    //            $"ClockTime MUST be reported in W3C ISO 8601 format.",
+                    //            SourceNode));
+                    //    }
+                    //    break;
+                    case Contracts.Enums.Devices.DataItemTypes.SampleTypes.ORIENTATION:
+                        if (Value.Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries).Length != 3 || Value.Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries).All(o => decimal.TryParse(o, out _)) == false)
+                        {
+                            validationErrors.Add(new MtconnectValidationException(
+                                ValidationSeverity.ERROR,
+                                $"ORIENTATION value MUST be three space-delimited floating-point numbers.",
+                                SourceNode));
+                        }
+                        break;
+                    case Contracts.Enums.Devices.DataItemTypes.SampleTypes.PATH_POSITION:
+                        if (!Value.Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries).All(o => decimal.TryParse(o, out _)))
+                        {
+                            validationErrors.Add(new MtconnectValidationException(
+                                ValidationSeverity.ERROR,
+                                $"PATH_POSITION value MUST be reported as a set of space-delimited floating-point numbers.",
+                                SourceNode));
+                        }
+                        break;
+                    default:
+                        break;
+                }
             }
 
             return !validationErrors.Any(o => o.Severity == ValidationSeverity.ERROR);

--- a/MtconnectTranspiler.Sinks.MtconnectCore/Models/MtconnectCoreEnum.cs
+++ b/MtconnectTranspiler.Sinks.MtconnectCore/Models/MtconnectCoreEnum.cs
@@ -11,6 +11,9 @@ namespace MtconnectTranspiler.Sinks.MtconnectCore.Models
         // NOTE: Only used for CATEGORY types that have subTypes.
         public Dictionary<string, string> SubTypes { get; set; } = new Dictionary<string, string>();
 
+        // NOTE: Only used for CATEGORY types that have value enums.
+        public Dictionary<string, string> Values { get; set; } = new Dictionary<string, string>();
+
         public MtconnectCoreEnum(MTConnectModel model, XmiElement source, string name) : base(model, source, name) { }
 
         public MtconnectCoreEnum(MTConnectModel model, UmlEnumeration source) : base(model, source) { }

--- a/MtconnectTranspiler.Sinks.MtconnectCore/Models/MtconnectCoreEnum.cs
+++ b/MtconnectTranspiler.Sinks.MtconnectCore/Models/MtconnectCoreEnum.cs
@@ -12,7 +12,7 @@ namespace MtconnectTranspiler.Sinks.MtconnectCore.Models
         public Dictionary<string, string> SubTypes { get; set; } = new Dictionary<string, string>();
 
         // NOTE: Only used for CATEGORY types that have value enums.
-        public Dictionary<string, string> Values { get; set; } = new Dictionary<string, string>();
+        public Dictionary<string, string> ValueTypes { get; set; } = new Dictionary<string, string>();
 
         public MtconnectCoreEnum(MTConnectModel model, XmiElement source, string name) : base(model, source, name) { }
 

--- a/MtconnectTranspiler.Sinks.MtconnectCore/Templates/MtconnectCore.Enum.scriban
+++ b/MtconnectTranspiler.Sinks.MtconnectCore/Templates/MtconnectCore.Enum.scriban
@@ -23,8 +23,11 @@ namespace {{ to_pascal_code source.namespace }}
 		[Obsolete("Deprecated according to https://model.mtconnect.org/")]
 		{{~ end ~}}
 		{{ include 'MtconnectVersionApplicability.scriban' item }}
-		{{~ if category_contains source item ~}}
+		{{~ if category_contains_type source item ~}}
 		[ObservationalSubType(typeof({{ source?.sub_types[item.name] }}))]
+{{ end ~}}
+		{{~ if category_contains_value source item ~}}
+		[ObservationalValue(typeof({{ source?.value_types[item.name] }}))]
 {{ end ~}}
 		{{ item.name }},
 	{{~ end ~}}

--- a/MtconnectTranspiler.Sinks.MtconnectCore/Templates/MtconnectCore.Enum.scriban
+++ b/MtconnectTranspiler.Sinks.MtconnectCore/Templates/MtconnectCore.Enum.scriban
@@ -1,6 +1,9 @@
 ﻿using System;
 using System.CodeDom.Compiler;
 using MtconnectCore.Standard.Contracts.Attributes;
+{{~ if enum_has_values source ~}}
+using MtconnectCore.Standard.Contracts.Enums.Streams;
+{{ end ~}}
 
 namespace {{ to_pascal_code source.namespace }}
 {

--- a/MtconnectTranspiler.Sinks.MtconnectCore/Transpiler.cs
+++ b/MtconnectTranspiler.Sinks.MtconnectCore/Transpiler.cs
@@ -76,9 +76,16 @@ namespace MtconnectTranspiler.Sinks.MtconnectCore
                             ?.Profile
                             ?.ProfileDataTypes
                             ?.Elements
-                            ?.FirstOrDefault(o => o is UmlEnumeration && o.Id == typeResult.Id);
-                        var typeValuesEnum = new MtconnectCoreEnum(model, typeValuesSysEnum as UmlEnumeration, $"{type.Name}Values");
-                        valueEnums.Add(typeValuesEnum);
+                            ?.FirstOrDefault(o => o is UmlEnumeration && o.Id == typeResult.PropertyType);
+                        if (typeValuesSysEnum != null)
+                        {
+                            var typeValuesEnum = new MtconnectCoreEnum(model, typeValuesSysEnum as UmlEnumeration) { Namespace = DataItemValueNamespace, Name = $"{type.Name}Values" };
+                            foreach (var value in typeValuesEnum.Items)
+                            {
+                                value.Name = value.SysML_Name;
+                            }
+                            valueEnums.Add(typeValuesEnum);
+                        }
                     }
 
                     // Add subType as enum
@@ -87,9 +94,9 @@ namespace MtconnectTranspiler.Sinks.MtconnectCore
                         // Register type as having a subType in the CATEGORY enum
                         if (!categoryEnum.SubTypes.ContainsKey(type.Name)) categoryEnum.SubTypes.Add(ScribanHelperMethods.ToUpperSnakeCode(type.Name), $"{type.Name}SubTypes");
 
-                        var typeSubTypes = subTypes[type.Name];
                         var subTypeEnum = new MtconnectCoreEnum(model, type, $"{type.Name}SubTypes") { Namespace = DataItemNamespace };
 
+                        var typeSubTypes = subTypes[type.Name];
                         subTypeEnum.AddItems(model, typeSubTypes);
 
                         // Cleanup Enum names

--- a/MtconnectTranspiler.Sinks.MtconnectCore/Transpiler.cs
+++ b/MtconnectTranspiler.Sinks.MtconnectCore/Transpiler.cs
@@ -12,7 +12,8 @@ namespace MtconnectTranspiler.Sinks.MtconnectCore
     public class CategoryFunctions : ScriptObject
     {
         public static bool CategoryContainsType(MtconnectCoreEnum @enum, EnumItem item) => @enum.SubTypes.ContainsKey(item.Name);
-        public static bool CategoryContainsValue(MtconnectCoreEnum @enum, EnumItem item) => @enum.Values.ContainsKey(item.Name);
+        public static bool CategoryContainsValue(MtconnectCoreEnum @enum, EnumItem item) => @enum.ValueTypes.ContainsKey(item.Name);
+        public static bool EnumHasValues(MtconnectCoreEnum @enum) => @enum.ValueTypes.Any();
     }
     internal class Transpiler : CsharpTranspiler
     {
@@ -85,7 +86,7 @@ namespace MtconnectTranspiler.Sinks.MtconnectCore
                             {
                                 value.Name = value.SysML_Name;
                             }
-                            if (!categoryEnum.Values.ContainsKey(type.Name)) categoryEnum.Values.Add(ScribanHelperMethods.ToUpperSnakeCode(type.Name), $"{type.Name}Values");
+                            if (!categoryEnum.ValueTypes.ContainsKey(type.Name)) categoryEnum.ValueTypes.Add(ScribanHelperMethods.ToUpperSnakeCode(type.Name), $"{type.Name}Values");
                             valueEnums.Add(typeValuesEnum);
                         }
                     }

--- a/MtconnectTranspiler.Sinks.MtconnectCore/Transpiler.cs
+++ b/MtconnectTranspiler.Sinks.MtconnectCore/Transpiler.cs
@@ -11,7 +11,8 @@ namespace MtconnectTranspiler.Sinks.MtconnectCore
 {
     public class CategoryFunctions : ScriptObject
     {
-        public static bool CategoryContains(MtconnectCoreEnum @enum, EnumItem item) => @enum.SubTypes.ContainsKey(item.Name);
+        public static bool CategoryContainsType(MtconnectCoreEnum @enum, EnumItem item) => @enum.SubTypes.ContainsKey(item.Name);
+        public static bool CategoryContainsValue(MtconnectCoreEnum @enum, EnumItem item) => @enum.Values.ContainsKey(item.Name);
     }
     internal class Transpiler : CsharpTranspiler
     {
@@ -84,6 +85,7 @@ namespace MtconnectTranspiler.Sinks.MtconnectCore
                             {
                                 value.Name = value.SysML_Name;
                             }
+                            if (!categoryEnum.Values.ContainsKey(type.Name)) categoryEnum.Values.Add(ScribanHelperMethods.ToUpperSnakeCode(type.Name), $"{type.Name}Values");
                             valueEnums.Add(typeValuesEnum);
                         }
                     }


### PR DESCRIPTION
 - Added `ObservationalValue` attribute to help indicate when `type`s have another enum of possible values
 - Included rendering of `ObservationalValue` in scriban template
 - Used the transpiler to update `EventTypes`
 - Updated Streams Event to validate values based on possible `ObservationalValue` attribute
 - Fixed some SubType validation