### PR TITLE
Version regex abstraction

### DIFF
--- a/MtconnectCore/MtconnectCore.csproj
+++ b/MtconnectCore/MtconnectCore.csproj
@@ -17,10 +17,10 @@
     <Description>Provides methods for communicating with MTConnect Agents as well as parsing the XML into DTOs modeled off the MTConnect standard.</Description>
     <RepositoryUrl>https://github.com/TrueAnalyticsSolutions/MtconnectCore</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
-    <PackageReleaseNotes>Changed the methodology for producing validation results. Errors were no longer bubbling up to the root document.</PackageReleaseNotes>
+    <PackageReleaseNotes>Changed Regex to identify the version of the schema in cases where a local schema file is referenced.</PackageReleaseNotes>
     <AssemblyVersion></AssemblyVersion>
     <FileVersion></FileVersion>
-    <Version>2.1.0.6</Version>
+    <Version>2.1.0.7</Version>
   </PropertyGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)'=='net45'">

--- a/MtconnectCore/Standard/Contracts/VersionHelper.cs
+++ b/MtconnectCore/Standard/Contracts/VersionHelper.cs
@@ -109,7 +109,7 @@ namespace MtconnectCore.Standard.Contracts
         public static MtconnectVersions GetVersionFromDocument(XmlDocument xDoc)
         {
             MtconnectVersions? version = null;
-            Regex regVersion = new Regex(@"^urn\:mtconnect.(org|com)\:(.*?)\:(?<version>.*?)$");
+            Regex regVersion = new Regex(@"^(?<schema>.*?)\:(?<address>.*?)\:(?<documenttype>.*?)\:(?<version>.*?)$");
             string docDefaultNamespace = xDoc.DocumentElement.GetAttribute("xmlns");
             string strDocVersion = string.Empty;
             var match = regVersion.Match(docDefaultNamespace);


### PR DESCRIPTION
Abstracted the Regex for extracting the version of the schema. This should allow multiple schemas and addresses, including local files.