### PR TITLE
Tbm0115/bug fixes

### DIFF
--- a/MtconnectCore/MtconnectCore.csproj
+++ b/MtconnectCore/MtconnectCore.csproj
@@ -21,7 +21,7 @@
     <PackageReleaseNotes>Changed Regex to identify the version of the schema in cases where a local schema file is referenced.</PackageReleaseNotes>
     <AssemblyVersion></AssemblyVersion>
     <FileVersion></FileVersion>
-    <Version>2.3.0.6</Version>
+    <Version>2.3.0.7</Version>
     <IncludeSymbols>True</IncludeSymbols>
     <SymbolPackageFormat>symbols.nupkg</SymbolPackageFormat>
   </PropertyGroup>

--- a/MtconnectCore/MtconnectCore.xml
+++ b/MtconnectCore/MtconnectCore.xml
@@ -1539,6 +1539,57 @@
             The optional name of the DataItemRef. Only informative.
             </summary>
         </member>
+        <member name="F:MtconnectCore.Standard.Contracts.Enums.Devices.Attributes.DeviceAttributes.UUID">
+            <summary>
+            universally unique identifier for the element.
+            </summary>
+        </member>
+        <member name="F:MtconnectCore.Standard.Contracts.Enums.Devices.Attributes.DeviceAttributes.NAME">
+            <summary>
+            name of an element or a piece of equipment.
+            </summary>
+        </member>
+        <member name="F:MtconnectCore.Standard.Contracts.Enums.Devices.Attributes.DeviceAttributes.ID">
+            <summary>
+            unique identifier for the Component.
+            </summary>
+        </member>
+        <member name="F:MtconnectCore.Standard.Contracts.Enums.Devices.Attributes.DeviceAttributes.SAMPLE_INTERVAL">
+            <summary>
+            interval in milliseconds between the completion of the reading of the data associated with the Component until the beginning of the next sampling of that data.
+            This information may be used by client software applications to understand how often information from a Component is expected to be refreshed.
+            </summary>
+        </member>
+        <member name="F:MtconnectCore.Standard.Contracts.Enums.Devices.Attributes.DeviceAttributes.NATIVE_NAME">
+            <summary>
+            common name associated with Component.
+            </summary>
+        </member>
+        <member name="F:MtconnectCore.Standard.Contracts.Enums.Devices.Attributes.DeviceAttributes.SAMPLE_RATE">
+            <summary>
+            DEPRECATED in MTConnect Version 1.2. Replaced by Component::sampleInterval.
+            </summary>
+        </member>
+        <member name="F:MtconnectCore.Standard.Contracts.Enums.Devices.Attributes.DeviceAttributes.ISO_841_CLASS">
+            <summary>
+            DEPRECATED in MTConnect Version 1.2.
+            </summary>
+        </member>
+        <member name="F:MtconnectCore.Standard.Contracts.Enums.Devices.Attributes.DeviceAttributes.MTCONNECT_VERSION">
+            <summary>
+            MTConnect version of the Device Information Model used to configure the information to be published for a piece of equipment in an MTConnect Response Document.
+            </summary>
+        </member>
+        <member name="F:MtconnectCore.Standard.Contracts.Enums.Devices.Attributes.DeviceAttributes.HASH">
+            <summary>
+            condensed message digest from a secure one-way hash function. FIPS PUB 180-4
+            </summary>
+        </member>
+        <member name="F:MtconnectCore.Standard.Contracts.Enums.Devices.Attributes.DeviceAttributes.COORDINATE_SYSTEM_ID_REF">
+            <summary>
+            specifies the  CoordinateSystem for this Component and its children.
+            </summary>
+        </member>
         <member name="T:MtconnectCore.Standard.Contracts.Enums.Devices.Attributes.DeviceRelationshipAttributes">
             <summary>
             DeviceRelationship describes the association between two pieces of equipment that function independently but together perform a manufacturing operation.
@@ -10624,6 +10675,63 @@
             value of the  Cell.
             </summary>
         </member>
+        <member name="F:MtconnectCore.Standard.Contracts.Enums.Streams.Attributes.ComponentAttributes.COMPONENT_ID">
+            <summary>
+            identifier of the Component as defined by the Component::id in the MTConnectDevices Response Document.
+            </summary>
+        </member>
+        <member name="F:MtconnectCore.Standard.Contracts.Enums.Streams.Attributes.ComponentAttributes.NAME">
+            <summary>
+            name of the Component associated with the ComponentStream.
+            </summary>
+        </member>
+        <member name="F:MtconnectCore.Standard.Contracts.Enums.Streams.Attributes.ComponentAttributes.NATIVE_NAME">
+            <summary>
+            common name of the Component associated with the  ComponentStream.
+            </summary>
+        </member>
+        <member name="F:MtconnectCore.Standard.Contracts.Enums.Streams.Attributes.ComponentAttributes.COMPONENT">
+            <summary>
+            identifies the Component type associated with the ComponentStream.
+            Examples of  ComponentStream::component are  Device,  Controller,  Linear and  Loader.
+            </summary>
+        </member>
+        <member name="F:MtconnectCore.Standard.Contracts.Enums.Streams.Attributes.ComponentAttributes.UUID">
+            <summary>
+            uuid of the Component associated with the  ComponentStream.
+            </summary>
+        </member>
+        <member name="F:MtconnectCore.Standard.Contracts.Enums.Streams.Attributes.ConditionAttributes.NATIVE_CODE">
+            <summary>
+            native code is the proprietary identifier designating a specific alarm, fault or warning code provided by the piece of equipment.
+            </summary>
+        </member>
+        <member name="F:MtconnectCore.Standard.Contracts.Enums.Streams.Attributes.ConditionAttributes.NATIVE_SEVERITY">
+            <summary>
+            severity information to a client software application if the piece of equipment designates a severity level to a fault.
+            </summary>
+        </member>
+        <member name="F:MtconnectCore.Standard.Contracts.Enums.Streams.Attributes.ConditionAttributes.QUALIFIER">
+            <summary>
+            additional information regarding a condition state associated with the measured value of a process variable.
+            Condition::qualifier defines whether the condition state represented indicates a measured value that is above or below an expected value of a process variable.
+            </summary>
+        </member>
+        <member name="F:MtconnectCore.Standard.Contracts.Enums.Streams.Attributes.ConditionAttributes.STATISTIC">
+            <summary>
+            Condition::statistic provides additional information describing the meaning of the Condition entity.
+            Condition::statistic MUST match the  DataItem::statistic defined in the MTConnectDevices Response Document.
+            </summary>
+        </member>
+        <member name="F:MtconnectCore.Standard.Contracts.Enums.Streams.Attributes.ConditionAttributes.CONDITION_ID">
+            <summary>
+            identifier of an individual condition activation provided by a piece of equipment.
+            Condition::conditionId MUST be unique for all concurrent condition activation.
+            Condition::conditionId MUST be maintained for all state transitions related to the same condition activation.
+            Multiple Condition::conditionIds MAY exist for the same  Condition::nativeCode.
+            If Condition::conditionId is not given, the value is the Condition::nativeCode. If Condition::nativeCode and  Condition::conditionId are not given, Condition::conditionId MUST be generated.
+            </summary>
+        </member>
         <member name="T:MtconnectCore.Standard.Contracts.Enums.Streams.Attributes.DataSetAttributes">
             <summary>
             Attributes for the <c>DATA_SET</c> representation
@@ -10632,6 +10740,16 @@
         <member name="F:MtconnectCore.Standard.Contracts.Enums.Streams.Attributes.DestinationAttributes.DEVICE_UUID">
             <summary>
             uuid of the target device or application.
+            </summary>
+        </member>
+        <member name="F:MtconnectCore.Standard.Contracts.Enums.Streams.Attributes.DeviceAttributes.NAME">
+            <summary>
+            name of the Device.
+            </summary>
+        </member>
+        <member name="F:MtconnectCore.Standard.Contracts.Enums.Streams.Attributes.DeviceAttributes.UUID">
+            <summary>
+            uuid of the Device.
             </summary>
         </member>
         <member name="T:MtconnectCore.Standard.Contracts.Enums.Streams.Attributes.DiscreteAttributes">
@@ -10657,6 +10775,12 @@
         <member name="F:MtconnectCore.Standard.Contracts.Enums.Streams.Attributes.EntryAttributes.RESULT">
             <summary>
             value of the  Entry.
+            </summary>
+        </member>
+        <member name="F:MtconnectCore.Standard.Contracts.Enums.Streams.Attributes.EventAttributes.RESET_TRIGGERED">
+            <summary>
+            identifies when a reported value has been reset and what has caused that reset to occur for those  DataItem entities that may be periodically reset to an initial value.
+            resetTriggered MUST only be provided for the specific occurrence of a  DataItem reported in the MTConnectStreams Response Document when the reset occurred.
             </summary>
         </member>
         <member name="F:MtconnectCore.Standard.Contracts.Enums.Streams.Attributes.FileAttributes.SIZE">
@@ -10689,7 +10813,11 @@
             The name of the FileProperty
             </summary>
         </member>
-        <!-- Badly formed XML comment ignored for member "F:MtconnectCore.Standard.Contracts.Enums.Streams.Attributes.ObservationAttributes.COMPOSITION_ID" -->
+        <member name="F:MtconnectCore.Standard.Contracts.Enums.Streams.Attributes.ObservationAttributes.COMPOSITION_ID">
+            <summary>
+            identifier of the Composition entity defined in the MTConnectDevices Response Document associated with the data reported for the  Observation.
+            </summary>
+        </member>
         <member name="F:MtconnectCore.Standard.Contracts.Enums.Streams.Attributes.ObservationAttributes.DATA_ITEM_ID">
             <summary>
             unique identifier of the  DataItem associated with this  Observation.
@@ -10788,6 +10916,28 @@
         <member name="F:MtconnectCore.Standard.Contracts.Enums.Streams.Attributes.ResetTriggers.WEEK">
             <summary>
             The value of the Data Entity was reset at the end of a 7-day period.
+            </summary>
+        </member>
+        <member name="F:MtconnectCore.Standard.Contracts.Enums.Streams.Attributes.SampleAttributes.SAMPLE_RATE">
+            <summary>
+            rate at which successive samples of the value are recorded.
+            </summary>
+        </member>
+        <member name="F:MtconnectCore.Standard.Contracts.Enums.Streams.Attributes.SampleAttributes.RESET_TRIGGERED">
+            <summary>
+            identifies when a reported value has been reset and what has caused that reset to occur for those  DataItem entities that may be periodically reset to an initial value.
+            resetTriggered MUST only be provided for the specific occurrence of a  DataItem reported in the MTConnectStreams Response Document when the reset occurred.
+            </summary>
+        </member>
+        <member name="F:MtconnectCore.Standard.Contracts.Enums.Streams.Attributes.SampleAttributes.STATISTIC">
+            <summary>
+            type of statistical calculation defined by the  DataItem::statistic defined in the MTConnectDevices Response Document.
+            </summary>
+        </member>
+        <member name="F:MtconnectCore.Standard.Contracts.Enums.Streams.Attributes.SampleAttributes.DURATION">
+            <summary>
+            time-period over which the data was collected.
+            Sample::duration MUST be provided when the  DataItem::statistic is defined in the MTConnectDevices Response Document.
             </summary>
         </member>
         <member name="T:MtconnectCore.Standard.Contracts.Enums.Streams.Attributes.TableAttributes">
@@ -14018,7 +14168,9 @@
             <inheritdoc />
         </member>
         <member name="T:MtconnectCore.Standard.Documents.Devices.DataItem">
-            <inheritdoc />
+            <summary>
+            information reported about a piece of equipment. <see href="https://model.mtconnect.org/#Structure__EAID_002C94B7_1257_49be_8EAA_CE7FCD7AFF8A">MTConnect Model Browser</see>
+            </summary>
         </member>
         <member name="P:MtconnectCore.Standard.Documents.Devices.DataItem.Id">
             <inheritdoc cref="F:MtconnectCore.Standard.Contracts.Enums.Devices.Attributes.DataItemAttributes.ID"/>
@@ -14167,6 +14319,15 @@
         </member>
         <member name="P:MtconnectCore.Standard.Documents.Devices.Device.Iso841Class">
             <inheritdoc cref="F:MtconnectCore.Standard.Contracts.Enums.Devices.Attributes.DeviceAttributes.ISO_841_CLASS"/>
+        </member>
+        <member name="P:MtconnectCore.Standard.Documents.Devices.Device.MtconnectVersionAttribute">
+            <inheritdoc cref="F:MtconnectCore.Standard.Contracts.Enums.Devices.Attributes.DeviceAttributes.MTCONNECT_VERSION"/>
+        </member>
+        <member name="P:MtconnectCore.Standard.Documents.Devices.Device.Hash">
+            <inheritdoc cref="F:MtconnectCore.Standard.Contracts.Enums.Devices.Attributes.DeviceAttributes.HASH"/>
+        </member>
+        <member name="P:MtconnectCore.Standard.Documents.Devices.Device.Configuration">
+            <inheritdoc cref="F:MtconnectCore.Standard.Contracts.Enums.Devices.Elements.ComponentElements.CONFIGURATION"/>
         </member>
         <member name="P:MtconnectCore.Standard.Documents.Devices.Device.References">
             <inheritdoc cref="F:MtconnectCore.Standard.Contracts.Enums.Devices.Elements.DeviceElements.REFERENCES"/>
@@ -14780,59 +14941,34 @@
             <inheritdoc/>
         </member>
         <member name="P:MtconnectCore.Standard.Documents.Streams.Component.ComponentId">
-            <summary>
-            Collected from the componentId attribute. Refer to Part 3 Streams - 4.3.2
-            
-            Occurance: 1
-            </summary>
+            <inheritdoc cref="F:MtconnectCore.Standard.Contracts.Enums.Streams.Attributes.ComponentAttributes.COMPONENT_ID"/>
         </member>
         <member name="P:MtconnectCore.Standard.Documents.Streams.Component.Name">
-            <summary>
-            Collected from the name attribute. Refer to Part 3 Streams - 4.3.2
-            
-            Occurance: 0..1
-            </summary>
+            <inheritdoc cref="F:MtconnectCore.Standard.Contracts.Enums.Streams.Attributes.ComponentAttributes.NAME"/>
         </member>
         <member name="P:MtconnectCore.Standard.Documents.Streams.Component.NativeName">
-            <summary>
-            Collected from the nativeName attribute. Refer to Part 3 Streams - 4.3.2
-            
-            Occurance: 0..1
-            </summary>
+            <inheritdoc cref="F:MtconnectCore.Standard.Contracts.Enums.Streams.Attributes.ComponentAttributes.NATIVE_NAME"/>
         </member>
         <member name="P:MtconnectCore.Standard.Documents.Streams.Component.ComponentReference">
-            <summary>
-            Collected from the component attribute. Refer to Part 3 Streams - 4.3.2
-            
-            Occurance: 1
-            </summary>
+            <inheritdoc cref="F:MtconnectCore.Standard.Contracts.Enums.Streams.Attributes.ComponentAttributes.COMPONENT"/>
         </member>
         <member name="P:MtconnectCore.Standard.Documents.Streams.Component.Uuid">
-            <summary>
-            Collected from the uuid attribute. Refer to Part 3 Streams - 4.3.2
-            
-            Occurance: 0..1
-            </summary>
+            <inheritdoc cref="F:MtconnectCore.Standard.Contracts.Enums.Streams.Attributes.ComponentAttributes.UUID"/>
         </member>
         <member name="P:MtconnectCore.Standard.Documents.Streams.Component.Samples">
             <summary>
-            Collected from Sample elements. Refer to Part 3 Streams - 4.3.3
-            
-            Occurance: 0..1
+            Samples groups one or more Sample entities. See Section Sample.
             </summary>
         </member>
         <member name="P:MtconnectCore.Standard.Documents.Streams.Component.Events">
             <summary>
-            Collected from Event elements. Refer to Part 3 Streams - 4.3.3
-            
-            Occurance: 0..1
+            Events groups one or more Event entities. See Section Event.
             </summary>
         </member>
         <member name="P:MtconnectCore.Standard.Documents.Streams.Component.Conditions">
             <summary>
-            Collected from Sample elements. Refer to Part 3 Streams - 4.3.3
-            
-            Occurance: 0..1
+            Conditions groups one or more Condition entities. See Section Condition.
+            Note: In the XML representation, Conditions MUST appear as Condition element in the MTConnectStreams Response Document.
             </summary>
         </member>
         <member name="M:MtconnectCore.Standard.Documents.Streams.Component.#ctor">
@@ -14842,32 +14978,19 @@
             <inheritdoc/>
         </member>
         <member name="P:MtconnectCore.Standard.Documents.Streams.Condition.NativeCode">
-            <summary>
-            Collected from the nativeCode attribute. Refer to Part 3 Streams - 5.8.3
-            
-            Occurance: 0..1
-            </summary>
+            <inheritdoc cref="F:MtconnectCore.Standard.Contracts.Enums.Streams.Attributes.ConditionAttributes.NATIVE_CODE"/>
         </member>
         <member name="P:MtconnectCore.Standard.Documents.Streams.Condition.NativeSeverity">
-            <summary>
-            Collected from the nativeSeverity attribute. Refer to Part 3 Streams - 5.8.3
-            
-            Occurance: 0..1
-            </summary>
+            <inheritdoc cref="F:MtconnectCore.Standard.Contracts.Enums.Streams.Attributes.ConditionAttributes.NATIVE_SEVERITY"/>
         </member>
         <member name="P:MtconnectCore.Standard.Documents.Streams.Condition.Qualifier">
-            <summary>
-            Collected from the qualifier attribute. Refer to Part 3 Streams - 5.8.3
-            
-            Occurance: 0..1
-            </summary>
+            <inheritdoc cref="F:MtconnectCore.Standard.Contracts.Enums.Streams.Attributes.ConditionAttributes.QUALIFIER"/>
         </member>
         <member name="P:MtconnectCore.Standard.Documents.Streams.Condition.Statistic">
-            <summary>
-            Collected from the statistic attribute. Refer to Part 3 Streams - 5.8.3
-            
-            Occurance: 0..1
-            </summary>
+            <inheritdoc cref="F:MtconnectCore.Standard.Contracts.Enums.Streams.Attributes.ConditionAttributes.STATISTIC"/>
+        </member>
+        <member name="P:MtconnectCore.Standard.Documents.Streams.Condition.ConditionId">
+            <inheritdoc cref="F:MtconnectCore.Standard.Contracts.Enums.Streams.Attributes.ConditionAttributes.CONDITION_ID"/>
         </member>
         <member name="P:MtconnectCore.Standard.Documents.Streams.Condition.Language">
             <summary>
@@ -14888,18 +15011,10 @@
             <inheritdoc/>
         </member>
         <member name="P:MtconnectCore.Standard.Documents.Streams.Device.Name">
-            <summary>
-            Collected from the name attribute. Refer to Part 3 Streams - 4.2.2
-            
-            Occurance: 1
-            </summary>
+            <inheritdoc cref="F:MtconnectCore.Standard.Contracts.Enums.Streams.Attributes.DeviceAttributes.NAME"/>
         </member>
         <member name="P:MtconnectCore.Standard.Documents.Streams.Device.Uuid">
-            <summary>
-            Collected from the uuid attribute. Refer to Part 3 Streams - 4.2.2
-            
-            Occurance: 1
-            </summary>
+            <inheritdoc cref="F:MtconnectCore.Standard.Contracts.Enums.Streams.Attributes.DeviceAttributes.UUID"/>
         </member>
         <member name="P:MtconnectCore.Standard.Documents.Streams.Device.Components">
             <summary>
@@ -15080,37 +15195,24 @@
             <inheritdoc/>
         </member>
         <member name="P:MtconnectCore.Standard.Documents.Streams.Sample.SampleRate">
-            <summary>
-            Collected from the sampleRate attribute. Refer to Part 3 Streams - 5.3.2
-            
-            Occurance: 0..1
-            </summary>
+            <inheritdoc cref="F:MtconnectCore.Standard.Contracts.Enums.Streams.Attributes.SampleAttributes.SAMPLE_RATE"/>
         </member>
         <member name="P:MtconnectCore.Standard.Documents.Streams.Sample.Statistic">
-            <summary>
-            Collected from the statistic attribute. Refer to Part 3 Streams - 5.3.2
-            
-            Occurance: 0..1
-            </summary>
+            <inheritdoc cref="F:MtconnectCore.Standard.Contracts.Enums.Streams.Attributes.SampleAttributes.STATISTIC"/>
         </member>
         <member name="P:MtconnectCore.Standard.Documents.Streams.Sample.Duration">
-            <summary>
-            Collected from the duration attribute. Refer to Part 3 Streams - 5.3.2
-            
-            Occurance: 0..1
-            </summary>
+            <inheritdoc cref="F:MtconnectCore.Standard.Contracts.Enums.Streams.Attributes.SampleAttributes.DURATION"/>
         </member>
         <member name="P:MtconnectCore.Standard.Documents.Streams.Sample.ResetTriggered">
-            <summary>
-            Collected from the resetTriggered attribute. Refer to Part 3 Streams - 5.3.2
-            
-            Occurance: 0..1
-            </summary>
+            <inheritdoc cref="F:MtconnectCore.Standard.Contracts.Enums.Streams.Attributes.SampleAttributes.RESET_TRIGGERED"/>
         </member>
         <member name="P:MtconnectCore.Standard.Documents.Streams.Sample.Value">
             <summary>
             Collected from the textcontent of the Sample element. Refer to Part 3 Streams - 5.3.3
             </summary>
+        </member>
+        <member name="P:MtconnectCore.Standard.Documents.Streams.Sample.SampleCount">
+            <inheritdoc cref="F:MtconnectCore.Standard.Contracts.Enums.Streams.Attributes.SampleAttributes.SAMPLE_COUNT"/>
         </member>
         <member name="M:MtconnectCore.Standard.Documents.Streams.Sample.#ctor">
             <inheritdoc/>

--- a/MtconnectCore/MtconnectCore.xml
+++ b/MtconnectCore/MtconnectCore.xml
@@ -10426,6 +10426,24 @@
         <member name="F:MtconnectCore.Standard.Contracts.Enums.MtconnectVersions.V_2_3_1">
             <inheritdoc cref="F:MtconnectCore.Standard.Contracts.Enums.MtconnectVersions.V_2_3_0"/>
         </member>
+        <member name="F:MtconnectCore.Standard.Contracts.Enums.MtconnectVersions.V_2_4_0">
+            <summary>
+            Version 2.4.0
+            </summary>
+            <remarks>Prepared on: July 16, 2024</remarks>
+        </member>
+        <member name="F:MtconnectCore.Standard.Contracts.Enums.MtconnectVersions.V_2_4_1">
+            <inheritdoc cref="F:MtconnectCore.Standard.Contracts.Enums.MtconnectVersions.V_2_4_0"/>
+        </member>
+        <member name="F:MtconnectCore.Standard.Contracts.Enums.MtconnectVersions.V_2_5_0">
+            <summary>
+            Version 2.5.0
+            </summary>
+            <remarks>Prepared on: January 16, 2025</remarks>
+        </member>
+        <member name="F:MtconnectCore.Standard.Contracts.Enums.MtconnectVersions.V_2_5_1">
+            <inheritdoc cref="F:MtconnectCore.Standard.Contracts.Enums.MtconnectVersions.V_2_5_0"/>
+        </member>
         <member name="T:MtconnectCore.Standard.Contracts.Enums.NodeTypes">
             <summary>
             Logical choices XML node types.
@@ -13089,6 +13107,44 @@
         </member>
         <member name="F:MtconnectCore.Standard.Contracts.VersionHelper.versionMinimumVersion">
             <remarks>Find this in the <c>MTConnectDevices_x.x.xsd</c> referenced at <c>/xs:schema[@vs:minVersion]</c></remarks>
+        </member>
+        <member name="M:MtconnectCore.Standard.Contracts.VersionHelper.GetVersion(System.String)">
+            <summary>
+            Searches for a MTConnect version by string. Note that this expects the format of the Enum field. For example, "V_1_0_1"
+            </summary>
+            <param name="version">String representation of the MTConnect Version.</param>
+            <returns></returns>
+        </member>
+        <member name="M:MtconnectCore.Standard.Contracts.VersionHelper.GetReleaseDate(MtconnectCore.Standard.Contracts.Enums.MtconnectVersions)">
+            <summary>
+            Looks up the official release date of the provided version.
+            </summary>
+            <param name="version">Version of MTConnect</param>
+            <returns>Official release date of the provided version.</returns>
+        </member>
+        <member name="M:MtconnectCore.Standard.Contracts.VersionHelper.GetVersionFromHeader(System.Xml.XmlDocument)">
+            <summary>
+            Gets the value of the <c>version</c> attribute that should be present in the <c>Header</c> element according to MTConnect.
+            </summary>
+            <param name="xDoc">Reference to the XML document</param>
+            <returns>Version of MTConnect as described by the <c>version</c> attribute in the <c>Header</c></returns>
+        </member>
+        <member name="M:MtconnectCore.Standard.Contracts.VersionHelper.GetVersionFromDocument(System.Xml.XmlDocument)">
+            <summary>
+            Parses the namespaces of the XML document to determine the version of MTConnect implemented.
+            </summary>
+            <param name="xDoc">Reference to the XML document</param>
+            <returns>Version of MTConnect implemented, based on the namespace definitions in the XML document. If no version could be parsed, then a default version is returned.</returns>
+        </member>
+        <member name="M:MtconnectCore.Standard.Contracts.VersionHelper.GetDocumentNamespaces(MtconnectCore.Standard.Contracts.Enums.MtconnectVersions,System.Xml.XmlDocument,System.String)">
+            <summary>
+            Constructs a namespace table for the XML document in order to use proper XPath.
+            </summary>
+            <param name="version">Reference to the version of MTConnect being used in the document.</param>
+            <param name="xDoc">Reference to the XML document</param>
+            <param name="defaultNamespace">Reference to the default namespace name (ie. <c>m</c>, or <c>mt</c>)</param>
+            <returns>XML name table</returns>
+            <exception cref="T:System.Exception"></exception>
         </member>
         <member name="P:MtconnectCore.Standard.CurrentRequestQuery.Path">
             <summary>

--- a/MtconnectCore/Standard/Contracts/Enums/Devices/Attributes/DeviceAttributes.cs
+++ b/MtconnectCore/Standard/Contracts/Enums/Devices/Attributes/DeviceAttributes.cs
@@ -1,13 +1,59 @@
-﻿namespace MtconnectCore.Standard.Contracts.Enums.Devices.Attributes
+﻿using MtconnectCore.Standard.Contracts.Attributes;
+
+namespace MtconnectCore.Standard.Contracts.Enums.Devices.Attributes
 {
     public enum DeviceAttributes
     {
+        /// <summary>
+        /// universally unique identifier for the element.
+        /// </summary>
+        [MtconnectVersionApplicability(MtconnectVersions.V_1_0_1, "https://model.mtconnect.org/#Structure___19_0_3_68e0225_1620240839406_285612_1596")]
         UUID,
+        /// <summary>
+        /// name of an element or a piece of equipment.
+        /// </summary>
+        [MtconnectVersionApplicability(MtconnectVersions.V_1_0_1, "https://model.mtconnect.org/#Structure___19_0_3_68e0225_1620240839406_285612_1596")]
         NAME,
+        /// <summary>
+        /// unique identifier for the Component.
+        /// </summary>
+        [MtconnectVersionApplicability(MtconnectVersions.V_1_0_1, "https://model.mtconnect.org/#Structure__EAID_8548C620_467A_4f50_9A22_58D84B7E8779")]
         ID,
+        /// <summary>
+        /// interval in milliseconds between the completion of the reading of the data associated with the Component until the beginning of the next sampling of that data.
+        /// This information may be used by client software applications to understand how often information from a Component is expected to be refreshed.
+        /// </summary>
+        [MtconnectVersionApplicability(MtconnectVersions.V_1_0_1, "https://model.mtconnect.org/#Structure__EAID_8548C620_467A_4f50_9A22_58D84B7E8779")]
         SAMPLE_INTERVAL,
+        /// <summary>
+        /// common name associated with Component.
+        /// </summary>
+        [MtconnectVersionApplicability(MtconnectVersions.V_1_0_1, "https://model.mtconnect.org/#Structure__EAID_8548C620_467A_4f50_9A22_58D84B7E8779")]
         NATIVE_NAME,
+        /// <summary>
+        /// DEPRECATED in MTConnect Version 1.2. Replaced by Component::sampleInterval.
+        /// </summary>
+        [MtconnectVersionApplicability(MtconnectVersions.V_1_0_1, "https://model.mtconnect.org/#Structure__EAID_8548C620_467A_4f50_9A22_58D84B7E8779")]
         SAMPLE_RATE,
-        ISO_841_CLASS
+        /// <summary>
+        /// DEPRECATED in MTConnect Version 1.2.
+        /// </summary>
+        [MtconnectVersionApplicability(MtconnectVersions.V_1_0_1, "https://model.mtconnect.org/#Structure___19_0_3_68e0225_1620240839406_285612_1596", MtconnectVersions.V_1_1_0)]
+        ISO_841_CLASS,
+        /// <summary>
+        /// MTConnect version of the Device Information Model used to configure the information to be published for a piece of equipment in an MTConnect Response Document.
+        /// </summary>
+        [MtconnectVersionApplicability(MtconnectVersions.V_1_7_0, "https://model.mtconnect.org/#Structure___19_0_3_68e0225_1620240839406_285612_1596")]
+        MTCONNECT_VERSION,
+        /// <summary>
+        /// condensed message digest from a secure one-way hash function. FIPS PUB 180-4
+        /// </summary>
+        [MtconnectVersionApplicability(MtconnectVersions.V_2_2_0, "https://model.mtconnect.org/#Structure___19_0_3_68e0225_1620240839406_285612_1596")]
+        HASH,
+        /// <summary>
+        /// specifies the  CoordinateSystem for this Component and its children.
+        /// </summary>
+        [MtconnectVersionApplicability(MtconnectVersions.V_1_0_1, "https://model.mtconnect.org/#Structure__EAID_8548C620_467A_4f50_9A22_58D84B7E8779")]
+        COORDINATE_SYSTEM_ID_REF
     }
 }

--- a/MtconnectCore/Standard/Contracts/Enums/MtconnectVersions.cs
+++ b/MtconnectCore/Standard/Contracts/Enums/MtconnectVersions.cs
@@ -117,5 +117,23 @@ namespace MtconnectCore.Standard.Contracts.Enums
         /// <inheritdoc cref="V_2_3_0"/>
         [Description("2.3.1")]
         V_2_3_1 = 1 << 22,
+        /// <summary>
+        /// Version 2.4.0
+        /// </summary>
+        /// <remarks>Prepared on: July 16, 2024</remarks>
+        [Description("2.4")]
+        V_2_4_0 = 1 << 23,
+        /// <inheritdoc cref="V_2_4_0"/>
+        [Description("2.4.1")]
+        V_2_4_1 = 1 << 24,
+        /// <summary>
+        /// Version 2.5.0
+        /// </summary>
+        /// <remarks>Prepared on: January 16, 2025</remarks>
+        [Description("2.5")]
+        V_2_5_0 = 1 << 25,
+        /// <inheritdoc cref="V_2_5_0"/>
+        [Description("2.5.1")]
+        V_2_5_1 = 1 << 26,
     }
 }

--- a/MtconnectCore/Standard/Contracts/Enums/Streams/Attributes/ComponentAttributes.cs
+++ b/MtconnectCore/Standard/Contracts/Enums/Streams/Attributes/ComponentAttributes.cs
@@ -1,11 +1,34 @@
-﻿namespace MtconnectCore.Standard.Contracts.Enums.Streams.Attributes
+﻿using MtconnectCore.Standard.Contracts.Attributes;
+
+namespace MtconnectCore.Standard.Contracts.Enums.Streams.Attributes
 {
     public enum ComponentAttributes
     {
+        /// <summary>
+        /// identifier of the Component as defined by the Component::id in the MTConnectDevices Response Document.
+        /// </summary>
+        [MtconnectVersionApplicability(MtconnectVersions.V_1_0_1, "https://model.mtconnect.org/#Structure__EAID_9057AAF9_4687_42be_BD2B_E2F18DF049DC")]
         COMPONENT_ID,
+        /// <summary>
+        /// name of the Component associated with the ComponentStream.
+        /// </summary>
+        [MtconnectVersionApplicability(MtconnectVersions.V_1_0_1, "https://model.mtconnect.org/#Structure__EAID_9057AAF9_4687_42be_BD2B_E2F18DF049DC")]
         NAME,
+        /// <summary>
+        /// common name of the Component associated with the  ComponentStream.
+        /// </summary>
+        [MtconnectVersionApplicability(MtconnectVersions.V_1_1_0, "https://model.mtconnect.org/#Structure__EAID_9057AAF9_4687_42be_BD2B_E2F18DF049DC")]
         NATIVE_NAME,
+        /// <summary>
+        /// identifies the Component type associated with the ComponentStream.
+        /// Examples of  ComponentStream::component are  Device,  Controller,  Linear and  Loader.
+        /// </summary>
+        [MtconnectVersionApplicability(MtconnectVersions.V_1_0_1, "https://model.mtconnect.org/#Structure__EAID_9057AAF9_4687_42be_BD2B_E2F18DF049DC")]
         COMPONENT,
+        /// <summary>
+        /// uuid of the Component associated with the  ComponentStream.
+        /// </summary>
+        [MtconnectVersionApplicability(MtconnectVersions.V_1_0_1, "https://model.mtconnect.org/#Structure__EAID_9057AAF9_4687_42be_BD2B_E2F18DF049DC")]
         UUID
     }
 }

--- a/MtconnectCore/Standard/Contracts/Enums/Streams/Attributes/ConditionAttributes.cs
+++ b/MtconnectCore/Standard/Contracts/Enums/Streams/Attributes/ConditionAttributes.cs
@@ -1,4 +1,6 @@
-﻿namespace MtconnectCore.Standard.Contracts.Enums.Streams.Attributes
+﻿using MtconnectCore.Standard.Contracts.Attributes;
+
+namespace MtconnectCore.Standard.Contracts.Enums.Streams.Attributes
 {
     public enum ConditionAttributes
     {
@@ -8,10 +10,37 @@
         DATA_ITEM_ID,
         COMPOSITION_ID,
         TYPE,
+        /// <summary>
+        /// native code is the proprietary identifier designating a specific alarm, fault or warning code provided by the piece of equipment.
+        /// </summary>
+        [MtconnectVersionApplicability(MtconnectVersions.V_1_1_0, "https://model.mtconnect.org/#Structure___19_0_3_45f01b9_1579566531113_85883_25726")]
         NATIVE_CODE,
+        /// <summary>
+        /// severity information to a client software application if the piece of equipment designates a severity level to a fault.
+        /// </summary>
+        [MtconnectVersionApplicability(MtconnectVersions.V_1_1_0, "https://model.mtconnect.org/#Structure___19_0_3_45f01b9_1579566531113_85883_25726")]
         NATIVE_SEVERITY,
+        /// <summary>
+        /// additional information regarding a condition state associated with the measured value of a process variable.
+        /// Condition::qualifier defines whether the condition state represented indicates a measured value that is above or below an expected value of a process variable.
+        /// </summary>
+        [MtconnectVersionApplicability(MtconnectVersions.V_1_1_0, "https://model.mtconnect.org/#Structure___19_0_3_45f01b9_1579566531113_85883_25726")]
         QUALIFIER,
+        /// <summary>
+        /// Condition::statistic provides additional information describing the meaning of the Condition entity.
+        /// Condition::statistic MUST match the  DataItem::statistic defined in the MTConnectDevices Response Document.
+        /// </summary>
+        [MtconnectVersionApplicability(MtconnectVersions.V_1_2_0, "https://model.mtconnect.org/#Structure___19_0_3_45f01b9_1579566531113_85883_25726")]
         STATISTIC,
-        SUB_TYPE
+        SUB_TYPE,
+        /// <summary>
+        /// identifier of an individual condition activation provided by a piece of equipment.
+        /// Condition::conditionId MUST be unique for all concurrent condition activation.
+        /// Condition::conditionId MUST be maintained for all state transitions related to the same condition activation.
+        /// Multiple Condition::conditionIds MAY exist for the same  Condition::nativeCode.
+        /// If Condition::conditionId is not given, the value is the Condition::nativeCode. If Condition::nativeCode and  Condition::conditionId are not given, Condition::conditionId MUST be generated.
+        /// </summary>
+        [MtconnectVersionApplicability(MtconnectVersions.V_2_3_0, "https://model.mtconnect.org/#Structure___19_0_3_45f01b9_1579566531113_85883_25726")]
+        CONDITION_ID
     }
 }

--- a/MtconnectCore/Standard/Contracts/Enums/Streams/Attributes/DeviceAttributes.cs
+++ b/MtconnectCore/Standard/Contracts/Enums/Streams/Attributes/DeviceAttributes.cs
@@ -1,7 +1,17 @@
-﻿namespace MtconnectCore.Standard.Contracts.Enums.Streams.Attributes
+﻿using MtconnectCore.Standard.Contracts.Attributes;
+
+namespace MtconnectCore.Standard.Contracts.Enums.Streams.Attributes
 {
     public enum DeviceAttributes {
+        /// <summary>
+        /// name of the Device.
+        /// </summary>
+        [MtconnectVersionApplicability(MtconnectVersions.V_1_0_1, "https://model.mtconnect.org/#Structure__EAID_02192189_58E6_456c_A679_CDDFF559DA00")]
         NAME,
-        UUID
+        /// <summary>
+        /// uuid of the Device.
+        /// </summary>
+        [MtconnectVersionApplicability(MtconnectVersions.V_1_0_1, "https://model.mtconnect.org/#Structure__EAID_02192189_58E6_456c_A679_CDDFF559DA00")]
+        UUID,
     }
 }

--- a/MtconnectCore/Standard/Contracts/Enums/Streams/Attributes/EventAttributes.cs
+++ b/MtconnectCore/Standard/Contracts/Enums/Streams/Attributes/EventAttributes.cs
@@ -1,4 +1,6 @@
-﻿namespace MtconnectCore.Standard.Contracts.Enums.Streams.Attributes
+﻿using MtconnectCore.Standard.Contracts.Attributes;
+
+namespace MtconnectCore.Standard.Contracts.Enums.Streams.Attributes
 {
     public enum EventAttributes
     {
@@ -8,6 +10,11 @@
         NAME,
         DATA_ITEM_ID,
         COMPOSITION_ID,
+        /// <summary>
+        /// identifies when a reported value has been reset and what has caused that reset to occur for those  DataItem entities that may be periodically reset to an initial value.
+        /// resetTriggered MUST only be provided for the specific occurrence of a  DataItem reported in the MTConnectStreams Response Document when the reset occurred.
+        /// </summary>
+        [MtconnectVersionApplicability(MtconnectVersions.V_1_4_0, "https://model.mtconnect.org/#Structure___19_0_3_45f01b9_1579566531115_47447_25730")]
         RESET_TRIGGERED
     }
 }

--- a/MtconnectCore/Standard/Contracts/Enums/Streams/Attributes/ObservationAttributes.cs
+++ b/MtconnectCore/Standard/Contracts/Enums/Streams/Attributes/ObservationAttributes.cs
@@ -1,48 +1,59 @@
-﻿using System;
+﻿using MtconnectCore.Standard.Contracts.Attributes;
+using System;
 
 namespace MtconnectCore.Standard.Contracts.Enums.Streams.Attributes
 {
     public enum ObservationAttributes
     {
         /// <summary>
-        /// identifier of the  <<abstract>> Composition entity defined in the MTConnectDevices Response Document associated with the data reported for the  Observation.
+        /// identifier of the Composition entity defined in the MTConnectDevices Response Document associated with the data reported for the  Observation.
         /// </summary>
+        [MtconnectVersionApplicability(MtconnectVersions.V_1_4_0, "https://model.mtconnect.org/#Structure___19_0_3_45f01b9_1579566531115_47734_25731")]
         COMPOSITION_ID,
         /// <summary>
         /// unique identifier of the  DataItem associated with this  Observation.
         /// </summary>
+        [MtconnectVersionApplicability(MtconnectVersions.V_1_0_1, "https://model.mtconnect.org/#Structure___19_0_3_45f01b9_1579566531115_47734_25731")]
         DATA_ITEM_ID,
         /// <summary>
         /// name of the  DataItem associated with this  Observation.
         /// </summary>
+        [MtconnectVersionApplicability(MtconnectVersions.V_1_0_1, "https://model.mtconnect.org/#Structure___19_0_3_45f01b9_1579566531115_47734_25731")]
         NAME,
         /// <summary>
         /// number representing the sequential position of an occurrence of an observation in the data buffer of an agent.
         /// </summary>
+        [MtconnectVersionApplicability(MtconnectVersions.V_1_0_1, "https://model.mtconnect.org/#Structure___19_0_3_45f01b9_1579566531115_47734_25731")]
         SEQUENCE,
         /// <summary>
         /// subtype of the  DataItem associated with this  Observation.
         /// </summary>
+        [MtconnectVersionApplicability(MtconnectVersions.V_1_2_0, "https://model.mtconnect.org/#Structure___19_0_3_45f01b9_1579566531115_47734_25731")]
         SUB_TYPE,
         /// <summary>
         /// most accurate time available to a piece of equipment that represents the point in time that the data reported was measured.
         /// </summary>
+        [MtconnectVersionApplicability(MtconnectVersions.V_1_0_1, "https://model.mtconnect.org/#Structure___19_0_3_45f01b9_1579566531115_47734_25731")]
         TIMESTAMP,
         /// <summary>
         /// type of the  DataItem associated with this  Observation.
         /// </summary>
+        [MtconnectVersionApplicability(MtconnectVersions.V_1_0_1, "https://model.mtconnect.org/#Structure___19_0_3_45f01b9_1579566531115_47734_25731")]
         TYPE,
         /// <summary>
         /// units of the  DataItem associated with this  Observation.
         /// </summary>
+        [MtconnectVersionApplicability(MtconnectVersions.V_1_0_1, "https://model.mtconnect.org/#Structure___19_0_3_45f01b9_1579566531115_47734_25731")]
         UNITS,
         /// <summary>
         /// when true, Observation::result is indeterminate.
         /// </summary>
+        [MtconnectVersionApplicability(MtconnectVersions.V_1_0_1, "https://model.mtconnect.org/#Structure___19_0_3_45f01b9_1579566531115_47734_25731")]
         IS_UNAVAILABLE,
         /// <summary>
         /// observation of the  Observation entity.
         /// </summary>
+        [MtconnectVersionApplicability(MtconnectVersions.V_1_0_1, "https://model.mtconnect.org/#Structure___19_0_3_45f01b9_1579566531115_47734_25731")]
         RESULT
     }
 }

--- a/MtconnectCore/Standard/Contracts/Enums/Streams/Attributes/SampleAttributes.cs
+++ b/MtconnectCore/Standard/Contracts/Enums/Streams/Attributes/SampleAttributes.cs
@@ -10,11 +10,29 @@ namespace MtconnectCore.Standard.Contracts.Enums.Streams.Attributes
         NAME,
         DATA_ITEM_ID,
         COMPOSITION_ID,
+        /// <summary>
+        /// rate at which successive samples of the value are recorded.
+        /// </summary>
+        [MtconnectVersionApplicability(MtconnectVersions.V_1_2_0, "https://model.mtconnect.org/#Structure___19_0_3_45f01b9_1579566531116_175117_25733")]
         SAMPLE_RATE,
+        /// <summary>
+        /// identifies when a reported value has been reset and what has caused that reset to occur for those  DataItem entities that may be periodically reset to an initial value.
+        /// resetTriggered MUST only be provided for the specific occurrence of a  DataItem reported in the MTConnectStreams Response Document when the reset occurred.
+        /// </summary>
+        [MtconnectVersionApplicability(MtconnectVersions.V_1_4_0, "https://model.mtconnect.org/#Structure___19_0_3_45f01b9_1579566531116_175117_25733")]
         RESET_TRIGGERED,
+        /// <summary>
+        /// type of statistical calculation defined by the  DataItem::statistic defined in the MTConnectDevices Response Document.
+        /// </summary>
+        [MtconnectVersionApplicability(MtconnectVersions.V_1_2_0, "https://model.mtconnect.org/#Structure___19_0_3_45f01b9_1579566531116_175117_25733")]
         STATISTIC,
+        /// <summary>
+        /// time-period over which the data was collected.
+        /// Sample::duration MUST be provided when the  DataItem::statistic is defined in the MTConnectDevices Response Document.
+        /// </summary>
+        [MtconnectVersionApplicability(MtconnectVersions.V_1_2_0, "https://model.mtconnect.org/#Structure___19_0_3_45f01b9_1579566531116_175117_25733")]
         DURATION,
-        [MtconnectVersionApplicability(MtconnectVersions.V_1_3_0, "Part 3 Section 3.8.2")]
+        [MtconnectVersionApplicability(MtconnectVersions.V_1_3_0, "https://model.mtconnect.org/#Structure___19_0_3_45f01b9_1579566531116_175117_25733")]
         SAMPLE_COUNT
     }
 }

--- a/MtconnectCore/Standard/Contracts/MtconnectNodeParser.cs
+++ b/MtconnectCore/Standard/Contracts/MtconnectNodeParser.cs
@@ -452,6 +452,15 @@ namespace MtconnectCore.Standard.Contracts
                 {
                     validationErrors = new List<MtconnectValidationException>();
 
+                    // Check if node has initialization errors
+                    if (item.InitializationErrors.Any())
+                    {
+                        foreach (var initializationError in item.InitializationErrors)
+                        {
+                            validationErrors.Add(initializationError);
+                        }
+                    }
+
                     // If none of the Applicibility attributes apply to the version associated with this node, then all should be good, right?
                     if (!ApplicibilityAttributes.Any(o => o.Compare(item.MtconnectVersion.GetValueOrDefault()))) return true;
 

--- a/MtconnectCore/Standard/Documents/Devices/Component.cs
+++ b/MtconnectCore/Standard/Documents/Devices/Component.cs
@@ -185,8 +185,8 @@ namespace MtconnectCore.Standard.Documents.Devices
         [MtconnectVersionApplicability(MtconnectVersions.V_1_0_1, "Part 2 Section 3.3.2")]
         private bool validateChildCount(out ICollection<MtconnectValidationException> validationErrors) {
             validationErrors = new List<MtconnectValidationException>();
-            if (SubComponents.Count <= 0 && DataItems.Count <= 0) {
-                validationErrors.Add(new MtconnectValidationException(ValidationSeverity.ERROR, $"At least one of Components or DataItems MUST be provided.", SourceNode));
+            if (SubComponents.Count <= 0 && DataItems.Count <= 0 && References.Count <= 0) {
+                validationErrors.Add(new MtconnectValidationException(ValidationSeverity.ERROR, $"Component MUST have at least one of Component, DataItem, or Reference entities.", SourceNode));
             }
             return !validationErrors.Any(o => o.Severity == ValidationSeverity.ERROR);
         }

--- a/MtconnectCore/Standard/Documents/Devices/Device.cs
+++ b/MtconnectCore/Standard/Documents/Devices/Device.cs
@@ -149,7 +149,7 @@ namespace MtconnectCore.Standard.Documents.Devices
             return !validationErrors.Any(o => o.Severity == ValidationSeverity.ERROR);
         }
 
-        [MtconnectVersionApplicability(MtconnectVersions.V_1_0_1, "Part 2 Section 3.4.1", MtconnectVersions.V_1_0_1)]
+        [MtconnectVersionApplicability(MtconnectVersions.V_1_0_1, "Part 2 Section 3.4.1", MtconnectVersions.V_1_1_0)]
         private bool validateIso841Class_Required(out ICollection<MtconnectValidationException> validationErrors) {
             validationErrors = new List<MtconnectValidationException>();
             if (string.IsNullOrEmpty(Iso841Class))
@@ -193,10 +193,17 @@ namespace MtconnectCore.Standard.Documents.Devices
         private bool validateDataItemAvailability(out ICollection<MtconnectValidationException> validationErrors)
         {
             validationErrors = new List<MtconnectValidationException>();
-            if (!DataItems.Any(o => o.Type == MtconnectCore.Standard.Contracts.Enums.Devices.DataItemTypes.EventTypes.AVAILABILITY.ToString()))
+
+            System.Func<DataItem, bool> containsAvailability = (o) => o.Type == MtconnectCore.Standard.Contracts.Enums.Devices.DataItemTypes.EventTypes.AVAILABILITY.ToString();
+            if (!DataItems.Any(containsAvailability))
             {
                 validationErrors.Add(new MtconnectValidationException(ValidationSeverity.ERROR, "Device MUST have an AVAILABILITY DataItem that represents this device is available to do work.", SourceNode));
             }
+            else if (DataItems.Count(containsAvailability) > 1)
+            {
+                validationErrors.Add(new MtconnectValidationException(ValidationSeverity.ERROR, "Multiplicity of AVAILABILITY observed by a Device is 1.", SourceNode));
+            }
+
             return !validationErrors.Any(o => o.Severity == ValidationSeverity.ERROR);
         }
 
@@ -204,13 +211,24 @@ namespace MtconnectCore.Standard.Documents.Devices
         private bool validateDataItemAssets(out ICollection<MtconnectValidationException> validationErrors)
         {
             validationErrors = new List<MtconnectValidationException>();
-            if (!DataItems.Any(o => o.Type == MtconnectCore.Standard.Contracts.Enums.Devices.DataItemTypes.EventTypes.ASSET_CHANGED.ToString()))
+
+            System.Func<DataItem, bool> containsAssetChanged = (o) => o.Type == MtconnectCore.Standard.Contracts.Enums.Devices.DataItemTypes.EventTypes.ASSET_CHANGED.ToString();
+            if (!DataItems.Any(containsAssetChanged))
             {
                 validationErrors.Add(new MtconnectValidationException(ValidationSeverity.ERROR, "Device MUST have an ASSET_CHANGED DataItem.", SourceNode));
+            } else if (DataItems.Count(containsAssetChanged) > 1)
+            {
+                validationErrors.Add(new MtconnectValidationException(ValidationSeverity.ERROR, "Multiplicity of ASSET_CHANGED observed by a Device is 1.", SourceNode));
             }
-            if (!DataItems.Any(o => o.Type == MtconnectCore.Standard.Contracts.Enums.Devices.DataItemTypes.EventTypes.ASSET_REMOVED.ToString()))
+
+            System.Func<DataItem, bool> containsAssetRemoved = (o) => o.Type == MtconnectCore.Standard.Contracts.Enums.Devices.DataItemTypes.EventTypes.ASSET_REMOVED.ToString();
+            if (!DataItems.Any(containsAssetRemoved))
             {
                 validationErrors.Add(new MtconnectValidationException(ValidationSeverity.ERROR, "Device MUST have an ASSET_REMOVED DataItem.", SourceNode));
+            }
+            else if (DataItems.Count(containsAssetRemoved) > 1)
+            {
+                validationErrors.Add(new MtconnectValidationException(ValidationSeverity.ERROR, "Multiplicity of ASSET_REMOVED observed by a Device is 1.", SourceNode));
             }
             return !validationErrors.Any(o => o.Severity == ValidationSeverity.ERROR);
         }

--- a/MtconnectCore/Standard/Documents/Devices/Device.cs
+++ b/MtconnectCore/Standard/Documents/Devices/Device.cs
@@ -14,6 +14,8 @@ namespace MtconnectCore.Standard.Documents.Devices
 {
     public class Device : MtconnectNode
     {
+        private const string MODEL_BROWSER_URL = "https://model.mtconnect.org/#Structure___19_0_3_68e0225_1620240839406_285612_1596";
+
         /// <inheritdoc cref="DeviceAttributes.UUID"/>
         [MtconnectNodeAttribute(DeviceAttributes.UUID)]
         public string Uuid { get; set; }
@@ -42,6 +44,14 @@ namespace MtconnectCore.Standard.Documents.Devices
         [MtconnectNodeAttribute(DeviceAttributes.ISO_841_CLASS)]
         public string Iso841Class { get; set; }
 
+        /// <inheritdoc cref="DeviceAttributes.MTCONNECT_VERSION"/>
+        [MtconnectNodeAttribute(DeviceAttributes.MTCONNECT_VERSION)]
+        public string MtconnectVersionAttribute { get; set; }
+
+        /// <inheritdoc cref="DeviceAttributes.HASH"/>
+        [MtconnectNodeAttribute(DeviceAttributes.HASH)]
+        public string Hash { get; set; }
+
         public int Size => _components?.Sum(o => o.Size) ?? 0;
 
         private List<Component> _components = new List<Component>();
@@ -58,6 +68,10 @@ namespace MtconnectCore.Standard.Documents.Devices
 
         [MtconnectNodeElements("Description", nameof(TrySetDescription), XmlNamespace = Constants.DEFAULT_DEVICES_XML_NAMESPACE)]
         public ComponentDescription Description { get; set; }
+
+        /// <inheritdoc cref="ComponentElements.CONFIGURATION"/>
+        [MtconnectNodeElements("Configuration", nameof(TrySetConfiguration), XmlNamespace = Constants.DEFAULT_DEVICES_XML_NAMESPACE)]
+        public ComponentConfiguration Configuration { get; set; }
 
         private List<Reference> _references = new List<Reference>();
         /// <inheritdoc cref="DeviceElements.REFERENCES"/>
@@ -81,6 +95,9 @@ namespace MtconnectCore.Standard.Documents.Devices
 
         public bool TrySetDescription(XmlNode xNode, XmlNamespaceManager nsmgr, out ComponentDescription componentDescription)
             => base.TrySet<ComponentDescription>(xNode, nsmgr, nameof(Description), out componentDescription);
+
+        public bool TrySetConfiguration(XmlNode xNode, XmlNamespaceManager nsmgr, out ComponentConfiguration componentConfiguration)
+            => base.TrySet<ComponentConfiguration>(xNode, nsmgr, nameof(Configuration), out componentConfiguration);
 
         public bool TryAddReference(XmlNode xNode, XmlNamespaceManager nsmgr, out Reference reference)
         {
@@ -109,7 +126,7 @@ namespace MtconnectCore.Standard.Documents.Devices
             return true;
         }
 
-        [MtconnectVersionApplicability(MtconnectVersions.V_1_0_1, "Part 2 Section 3.4.1")]
+        [MtconnectVersionApplicability(MtconnectVersions.V_1_0_1, MODEL_BROWSER_URL)]
         private bool validateId(out ICollection<MtconnectValidationException> validationErrors) {
             validationErrors = new List<MtconnectValidationException>();
             if (string.IsNullOrEmpty(Id)) {
@@ -118,7 +135,7 @@ namespace MtconnectCore.Standard.Documents.Devices
             return !validationErrors.Any(o => o.Severity == ValidationSeverity.ERROR);
         }
 
-        [MtconnectVersionApplicability(MtconnectVersions.V_1_0_1, "Part 2 Section 3.4.1")]
+        [MtconnectVersionApplicability(MtconnectVersions.V_1_0_1, MODEL_BROWSER_URL)]
         private bool validateName(out ICollection<MtconnectValidationException> validationErrors) {
             validationErrors = new List<MtconnectValidationException>();
             if (string.IsNullOrEmpty(Name))
@@ -131,7 +148,7 @@ namespace MtconnectCore.Standard.Documents.Devices
             return !validationErrors.Any(o => o.Severity == ValidationSeverity.ERROR);
         }
 
-        [MtconnectVersionApplicability(MtconnectVersions.V_1_2_0, "Part 2 Section 3.2")]
+        [MtconnectVersionApplicability(MtconnectVersions.V_1_2_0, MODEL_BROWSER_URL)]
         private bool validateUuid(out ICollection<MtconnectValidationException> validationErrors) {
             validationErrors = new List<MtconnectValidationException>();
             if (string.IsNullOrEmpty(Uuid))
@@ -149,7 +166,7 @@ namespace MtconnectCore.Standard.Documents.Devices
             return !validationErrors.Any(o => o.Severity == ValidationSeverity.ERROR);
         }
 
-        [MtconnectVersionApplicability(MtconnectVersions.V_1_0_1, "Part 2 Section 3.4.1", MtconnectVersions.V_1_1_0)]
+        [MtconnectVersionApplicability(MtconnectVersions.V_1_0_1, MODEL_BROWSER_URL, MtconnectVersions.V_1_1_0)]
         private bool validateIso841Class_Required(out ICollection<MtconnectValidationException> validationErrors) {
             validationErrors = new List<MtconnectValidationException>();
             if (string.IsNullOrEmpty(Iso841Class))
@@ -180,16 +197,49 @@ namespace MtconnectCore.Standard.Documents.Devices
             return !validationErrors.Any(o => o.Severity == ValidationSeverity.ERROR);
         }
 
-        [MtconnectVersionApplicability(MtconnectVersions.V_1_3_0, "Part 2 Section 4.2.3")]
+        [MtconnectVersionApplicability(MtconnectVersions.V_1_2_0, MODEL_BROWSER_URL)]
+        private bool validateIso841Class_Deprecated(out ICollection<MtconnectValidationException> validationErrors)
+        {
+            validationErrors = new List<MtconnectValidationException>();
+
+            if (!string.IsNullOrEmpty(Iso841Class))
+            {
+                validationErrors.Add(new MtconnectValidationException(
+                    ValidationSeverity.WARNING,
+                    $"Device 'iso841Class' was DEPRECATED in MTConnect Version 1.2.",
+                    SourceNode));
+
+                // Might as well validate the legitamacy of the attribute since it was added
+                if (!EnumHelper.Contains<Iso841ClassTypes>(Iso841Class))
+                {
+                    validationErrors.Add(new MtconnectValidationException(
+                        ValidationSeverity.WARNING,
+                        $"Device 'iso841Class' attribute MUST be one of the following: [{EnumHelper.ToListString<Iso841ClassTypes>(", ", string.Empty, string.Empty)}].",
+                        SourceNode));
+
+                }
+                else if (!EnumHelper.ValidateToVersion<Iso841ClassTypes>(Iso841Class, MtconnectVersion.GetValueOrDefault()))
+                {
+                    validationErrors.Add(new MtconnectValidationException(
+                        ValidationSeverity.WARNING,
+                        $"Device 'iso841Class' of '{Iso841Class}' is not supported in version '{MtconnectVersion}' of the MTConnect Standard.",
+                        SourceNode));
+                }
+            }
+
+            return !validationErrors.Any(o => o.Severity == ValidationSeverity.ERROR);
+        }
+
+        [MtconnectVersionApplicability(MtconnectVersions.V_1_3_0, MODEL_BROWSER_URL)]
         private bool validateDataItemCount(out ICollection<MtconnectValidationException> validationErrors) {
             validationErrors = new List<MtconnectValidationException>();
             if (DataItems.Count <= 0) {
-                validationErrors.Add(new MtconnectValidationException(ValidationSeverity.ERROR, "Device must have at least one DataItem. Every Device MUST report AVAILABILITY.", SourceNode));
+                validationErrors.Add(new MtconnectValidationException(ValidationSeverity.ERROR, "Device must have at least one DataItem. Every Device MUST report AVAILABILITY, ASSET_CHANGED, and ASSET_REMOVED.", SourceNode));
             }
             return !validationErrors.Any(o => o.Severity == ValidationSeverity.ERROR);
         }
 
-        [MtconnectVersionApplicability(MtconnectVersions.V_1_1_0, "Part 2 Section 5.1")]
+        [MtconnectVersionApplicability(MtconnectVersions.V_1_1_0, MODEL_BROWSER_URL)]
         private bool validateDataItemAvailability(out ICollection<MtconnectValidationException> validationErrors)
         {
             validationErrors = new List<MtconnectValidationException>();
@@ -207,7 +257,7 @@ namespace MtconnectCore.Standard.Documents.Devices
             return !validationErrors.Any(o => o.Severity == ValidationSeverity.ERROR);
         }
 
-        [MtconnectVersionApplicability(MtconnectVersions.V_1_6_0, "Part 2 Section 4.2")]
+        [MtconnectVersionApplicability(MtconnectVersions.V_1_6_0, MODEL_BROWSER_URL)]
         private bool validateDataItemAssets(out ICollection<MtconnectValidationException> validationErrors)
         {
             validationErrors = new List<MtconnectValidationException>();
@@ -232,5 +282,17 @@ namespace MtconnectCore.Standard.Documents.Devices
             }
             return !validationErrors.Any(o => o.Severity == ValidationSeverity.ERROR);
         }
+
+        [MtconnectVersionApplicability(MtconnectVersions.V_1_3_0, MODEL_BROWSER_URL)]
+        private bool validateContents(out ICollection<MtconnectValidationException> validationErrors)
+        {
+            validationErrors = new List<MtconnectValidationException>();
+            if (DataItems.Count <= 0 && Components.Count <= 0 && References.Count <= 0)
+            {
+                validationErrors.Add(new MtconnectValidationException(ValidationSeverity.ERROR, "Device MUST have at least one of Component, DataItem, or Reference entities.", SourceNode));
+            }
+            return !validationErrors.Any(o => o.Severity == ValidationSeverity.ERROR);
+        }
+
     }
 }

--- a/MtconnectCore/Standard/Documents/Devices/DevicesDocument.cs
+++ b/MtconnectCore/Standard/Documents/Devices/DevicesDocument.cs
@@ -40,19 +40,112 @@ namespace MtconnectCore.Standard.Documents.Devices
             => base.TryAdd<Device>(xNode, nsmgr, ref _items, out device);
 
         [MtconnectVersionApplicability(MtconnectVersions.V_1_0_1, "Part 2 Section 4.2.7")]
-        private bool validateUniqueDeviceIds(out ICollection<MtconnectValidationException> validationErrors) {
+        private bool validateUniqueDevices(out ICollection<MtconnectValidationException> validationErrors)
+        {
             validationErrors = new List<MtconnectValidationException>();
             var duplicateIds = new HashSet<string>();
+            var duplicateUuids = new HashSet<string>();
             foreach (var device in Items)
             {
-                if (Items.Count(o => o.Id == device.Id) > 1) {
+                if (Items.Count(o => o.Id == device.Id) > 1)
                     duplicateIds.Add(device.Id);
-                }
+                if (Items.Count(o => o.Uuid == device.Uuid) > 1)
+                    duplicateIds.Add(device.Uuid);
             }
+
             foreach (string duplicateId in duplicateIds)
             {
                 validationErrors.Add(new MtconnectValidationException(ValidationSeverity.ERROR, "Duplicate Device id found: " + duplicateId + ". Each Device id MUST be unique."));
             }
+            foreach (string duplicateUuid in duplicateUuids)
+            {
+                validationErrors.Add(new MtconnectValidationException(ValidationSeverity.ERROR, "Duplicate Device uuid found: " + duplicateUuid + ". Each Device uuid MUST be unique."));
+            }
+
+            return !validationErrors.Any(o => o.Severity == ValidationSeverity.ERROR);
+        }
+
+        [MtconnectVersionApplicability(MtconnectVersions.V_1_0_1, "Part 2 Section 4.2.7")]
+        private bool validateUniqueComponents(out ICollection<MtconnectValidationException> validationErrors)
+        {
+            validationErrors = new List<MtconnectValidationException>();
+            var duplicateIds = new HashSet<string>();
+            var duplicateUuids = new HashSet<string>();
+
+            var items = DataItemNavigator.GetAllComponents(this);
+            foreach (var item in items)
+            {
+                if (Items.Count(o => o.Id == item.Id) > 1)
+                    duplicateIds.Add(item.Id);
+                if (Items.Count(o => o.Uuid == item.Uuid) > 1)
+                    duplicateIds.Add(item.Uuid);
+            }
+            foreach (string duplicateId in duplicateIds)
+            {
+                validationErrors.Add(new MtconnectValidationException(ValidationSeverity.ERROR, "Duplicate Component id found: " + duplicateId + ". Each Component id MUST be unique."));
+            }
+            foreach (string duplicateUuid in duplicateUuids)
+            {
+                validationErrors.Add(new MtconnectValidationException(ValidationSeverity.ERROR, "Duplicate Component uuid found: " + duplicateUuid + ". Each Component uuid MUST be unique."));
+            }
+            return !validationErrors.Any(o => o.Severity == ValidationSeverity.ERROR);
+        }
+
+        [MtconnectVersionApplicability(MtconnectVersions.V_1_0_1, "Part 2 Section 4.2.7")]
+        private bool validateDataItems(out ICollection<MtconnectValidationException> validationErrors)
+        {
+            validationErrors = new List<MtconnectValidationException>();
+            var duplicateIds = new HashSet<string>();
+            var namespaces = new HashSet<string>();
+
+            var items = DataItemNavigator.GetAll(this);
+            foreach (var item in items)
+            {
+                // Check uniqueness of Id
+                if (Items.Count(o => o.Id == item.Id) > 1)
+                    duplicateIds.Add(item.Id);
+
+                // Check if type is extended
+                if (item.Type.Contains(":"))
+                {
+                    string typeExtension = item.Type.Substring(0, item.Type.IndexOf(":"));
+                    namespaces.Add(typeExtension);
+                }
+
+                // Check if subType is extended
+                if (item.SubType.Contains(":"))
+                {
+                    string subTypeExtension = item.SubType.Substring(0, item.SubType.IndexOf(":"));
+                    namespaces.Add(subTypeExtension);
+                }
+
+                // Check if units is extended
+                if (item.Units.Contains(":"))
+                {
+                    string unitsExtension = item.Units.Substring(0, item.Units.IndexOf(":"));
+                    namespaces.Add(unitsExtension);
+                }
+
+                // Check if nativeUnits is extended
+                if (item.NativeUnits.Contains(":"))
+                {
+                    string nativeUnitsExtension = item.NativeUnits.Substring(0, item.NativeUnits.IndexOf(":"));
+                    namespaces.Add(nativeUnitsExtension);
+                }
+            }
+            foreach (string duplicateId in duplicateIds)
+            {
+                validationErrors.Add(new MtconnectValidationException(ValidationSeverity.ERROR, "Duplicate DataItem id found: " + duplicateId + ". Each DataItem id MUST be unique."));
+            }
+            foreach (string extensionNamespace in namespaces)
+            {
+                string extensionUri = Source.DocumentElement.GetAttribute("xmlns:" + extensionNamespace);
+                if (string.IsNullOrEmpty(extensionUri))
+                {
+                    validationErrors.Add(new MtconnectValidationException(ValidationSeverity.ERROR, "Missing namespace reference for '" + extensionNamespace + "'."));
+                }
+            }
+
             return !validationErrors.Any(o => o.Severity == ValidationSeverity.ERROR);
         }
     }

--- a/MtconnectCore/Standard/Documents/Devices/DevicesDocument.cs
+++ b/MtconnectCore/Standard/Documents/Devices/DevicesDocument.cs
@@ -16,6 +16,8 @@ namespace MtconnectCore.Standard.Documents.Devices
     /// </summary>
     public class DevicesDocument : ResponseDocument<DevicesDocumentHeader, Device>
     {
+        private const string MODEL_BROWSER_URL = "https://model.mtconnect.org/#Structure___19_0_3_68e0225_1620240839406_285612_1596";
+
         /// <inheritdoc />
         public override DocumentTypes Type => DocumentTypes.Devices;
 
@@ -39,37 +41,45 @@ namespace MtconnectCore.Standard.Documents.Devices
         public override bool TryAddItem(XmlNode xNode, XmlNamespaceManager nsmgr, out Device device)
             => base.TryAdd<Device>(xNode, nsmgr, ref _items, out device);
 
-        [MtconnectVersionApplicability(MtconnectVersions.V_1_0_1, "Part 2 Section 4.2.7")]
-        private bool validateUniqueDevices(out ICollection<MtconnectValidationException> validationErrors)
+        [MtconnectVersionApplicability(MtconnectVersions.V_1_0_1, MODEL_BROWSER_URL)]
+        private bool validateDevices(out ICollection<MtconnectValidationException> validationErrors)
         {
             validationErrors = new List<MtconnectValidationException>();
             var duplicateIds = new HashSet<string>();
+            var duplicateNames = new HashSet<string>();
             var duplicateUuids = new HashSet<string>();
             foreach (var device in Items)
             {
                 if (Items.Count(o => o.Id == device.Id) > 1)
                     duplicateIds.Add(device.Id);
+                if (Items.Count(o => o.Name == device.Name) > 1)
+                    duplicateNames.Add(device.Name);
                 if (Items.Count(o => o.Uuid == device.Uuid) > 1)
-                    duplicateIds.Add(device.Uuid);
+                    duplicateUuids.Add(device.Uuid);
             }
 
             foreach (string duplicateId in duplicateIds)
             {
-                validationErrors.Add(new MtconnectValidationException(ValidationSeverity.ERROR, "Duplicate Device id found: " + duplicateId + ". Each Device id MUST be unique."));
+                validationErrors.Add(new MtconnectValidationException(ValidationSeverity.ERROR, "Duplicate Device 'id' found: " + duplicateId + ". Each Device 'id' MUST be unique."));
+            }
+            foreach (string duplicateName in duplicateNames)
+            {
+                validationErrors.Add(new MtconnectValidationException(ValidationSeverity.ERROR, "Duplicate Device 'name' found: " + duplicateName + ". Each Device 'name' MUST be unique."));
             }
             foreach (string duplicateUuid in duplicateUuids)
             {
-                validationErrors.Add(new MtconnectValidationException(ValidationSeverity.ERROR, "Duplicate Device uuid found: " + duplicateUuid + ". Each Device uuid MUST be unique."));
+                validationErrors.Add(new MtconnectValidationException(ValidationSeverity.ERROR, "Duplicate Device 'uuid' found: " + duplicateUuid + ". Each Device 'uuid' MUST be unique."));
             }
 
             return !validationErrors.Any(o => o.Severity == ValidationSeverity.ERROR);
         }
 
-        [MtconnectVersionApplicability(MtconnectVersions.V_1_0_1, "Part 2 Section 4.2.7")]
-        private bool validateUniqueComponents(out ICollection<MtconnectValidationException> validationErrors)
+        [MtconnectVersionApplicability(MtconnectVersions.V_1_0_1, MODEL_BROWSER_URL)]
+        private bool validateComponents(out ICollection<MtconnectValidationException> validationErrors)
         {
             validationErrors = new List<MtconnectValidationException>();
             var duplicateIds = new HashSet<string>();
+            var duplicateNames = new HashSet<string>();
             var duplicateUuids = new HashSet<string>();
 
             var items = DataItemNavigator.GetAllComponents(this);
@@ -77,25 +87,32 @@ namespace MtconnectCore.Standard.Documents.Devices
             {
                 if (Items.Count(o => o.Id == item.Id) > 1)
                     duplicateIds.Add(item.Id);
+                if (Items.Count(o => o.Name == item.Name) > 1)
+                    duplicateNames.Add(item.Name);
                 if (Items.Count(o => o.Uuid == item.Uuid) > 1)
-                    duplicateIds.Add(item.Uuid);
+                    duplicateUuids.Add(item.Uuid);
             }
             foreach (string duplicateId in duplicateIds)
             {
-                validationErrors.Add(new MtconnectValidationException(ValidationSeverity.ERROR, "Duplicate Component id found: " + duplicateId + ". Each Component id MUST be unique."));
+                validationErrors.Add(new MtconnectValidationException(ValidationSeverity.ERROR, "Duplicate Component 'id' found: " + duplicateId + ". Each Component 'id' MUST be unique."));
+            }
+            foreach (string duplicateName in duplicateNames)
+            {
+                validationErrors.Add(new MtconnectValidationException(ValidationSeverity.ERROR, "Duplicate Component 'name' found: " + duplicateName + ". Each Component 'name' MUST be unique."));
             }
             foreach (string duplicateUuid in duplicateUuids)
             {
-                validationErrors.Add(new MtconnectValidationException(ValidationSeverity.ERROR, "Duplicate Component uuid found: " + duplicateUuid + ". Each Component uuid MUST be unique."));
+                validationErrors.Add(new MtconnectValidationException(ValidationSeverity.ERROR, "Duplicate Component 'uuid' found: " + duplicateUuid + ". Each Component 'uuid' MUST be unique."));
             }
             return !validationErrors.Any(o => o.Severity == ValidationSeverity.ERROR);
         }
 
-        [MtconnectVersionApplicability(MtconnectVersions.V_1_0_1, "Part 2 Section 4.2.7")]
+        [MtconnectVersionApplicability(MtconnectVersions.V_1_0_1, MODEL_BROWSER_URL)]
         private bool validateDataItems(out ICollection<MtconnectValidationException> validationErrors)
         {
             validationErrors = new List<MtconnectValidationException>();
             var duplicateIds = new HashSet<string>();
+            var duplicateNames = new HashSet<string>();
             var namespaces = new HashSet<string>();
 
             var items = DataItemNavigator.GetAll(this);
@@ -105,29 +122,33 @@ namespace MtconnectCore.Standard.Documents.Devices
                 if (Items.Count(o => o.Id == item.Id) > 1)
                     duplicateIds.Add(item.Id);
 
+                // Check uniqueness of Name
+                if (Items.Count(o => o.Name == item.Name) > 1)
+                    duplicateNames.Add(item.Name);
+
                 // Check if type is extended
-                if (item.Type.Contains(":"))
+                if (!string.IsNullOrEmpty(item.Type) && item.Type.Contains(":"))
                 {
                     string typeExtension = item.Type.Substring(0, item.Type.IndexOf(":"));
                     namespaces.Add(typeExtension);
                 }
 
                 // Check if subType is extended
-                if (item.SubType.Contains(":"))
+                if (!string.IsNullOrEmpty(item.SubType) && item.SubType.Contains(":"))
                 {
                     string subTypeExtension = item.SubType.Substring(0, item.SubType.IndexOf(":"));
                     namespaces.Add(subTypeExtension);
                 }
 
                 // Check if units is extended
-                if (item.Units.Contains(":"))
+                if (!string.IsNullOrEmpty(item.Units) && item.Units.Contains(":"))
                 {
                     string unitsExtension = item.Units.Substring(0, item.Units.IndexOf(":"));
                     namespaces.Add(unitsExtension);
                 }
 
                 // Check if nativeUnits is extended
-                if (item.NativeUnits.Contains(":"))
+                if (!string.IsNullOrEmpty(item.NativeUnits) && item.NativeUnits.Contains(":"))
                 {
                     string nativeUnitsExtension = item.NativeUnits.Substring(0, item.NativeUnits.IndexOf(":"));
                     namespaces.Add(nativeUnitsExtension);
@@ -135,7 +156,11 @@ namespace MtconnectCore.Standard.Documents.Devices
             }
             foreach (string duplicateId in duplicateIds)
             {
-                validationErrors.Add(new MtconnectValidationException(ValidationSeverity.ERROR, "Duplicate DataItem id found: " + duplicateId + ". Each DataItem id MUST be unique."));
+                validationErrors.Add(new MtconnectValidationException(ValidationSeverity.ERROR, "Duplicate DataItem 'id' found: " + duplicateId + ". Each DataItem 'id' MUST be unique."));
+            }
+            foreach (string duplicateName in duplicateNames)
+            {
+                validationErrors.Add(new MtconnectValidationException(ValidationSeverity.ERROR, "Duplicate DataItem 'name' found: " + duplicateName + ". Each DataItem 'name' MUST be unique."));
             }
             foreach (string extensionNamespace in namespaces)
             {

--- a/MtconnectCore/Standard/Documents/ResponseDocumentHeader.cs
+++ b/MtconnectCore/Standard/Documents/ResponseDocumentHeader.cs
@@ -52,13 +52,13 @@ namespace MtconnectCore.Standard.Documents
             {
                 var baseResult = base.TryValidate(report);
 
-                const string documentationAttributes = "See Part 1 Section 6.5.1 of the MTConnect standard.";
+                const string documentationAttributes = "https://model.mtconnect.org/#Structure__EAID_2299B0B3_B209_47ae_B93A_BA694AD50051";
 
                 if (string.IsNullOrEmpty(AgentVersion))
                 {
                     validationContext.AddExceptions(new MtconnectValidationException(
                         Contracts.Enums.ValidationSeverity.ERROR,
-                        $"Response Document Header MUST include a 'version' attribute. {documentationAttributes}",
+                        $"Response Document Header MUST include a 'version' attribute.",
                         SourceNode));
                 }
 
@@ -66,7 +66,7 @@ namespace MtconnectCore.Standard.Documents
                 {
                     validationContext.AddExceptions(new MtconnectValidationException(
                         Contracts.Enums.ValidationSeverity.ERROR,
-                        $"Response Document Header MUST include a 'creationTime' attribute. {documentationAttributes}",
+                        $"Response Document Header MUST include a 'creationTime' attribute.",
                         SourceNode));
                 }
 
@@ -74,7 +74,7 @@ namespace MtconnectCore.Standard.Documents
                 {
                     validationContext.AddExceptions(new MtconnectValidationException(
                         Contracts.Enums.ValidationSeverity.ERROR,
-                        $"Response Document Header MUST include a 'instanceId' attribute. {documentationAttributes}",
+                        $"Response Document Header MUST include a 'instanceId' attribute.",
                         SourceNode));
                 }
 
@@ -82,7 +82,7 @@ namespace MtconnectCore.Standard.Documents
                 {
                     validationContext.AddExceptions(new MtconnectValidationException(
                         Contracts.Enums.ValidationSeverity.ERROR,
-                        $"Response Document Header MUST include a 'sender' attribute. {documentationAttributes}",
+                        $"Response Document Header MUST include a 'sender' attribute.",
                         SourceNode));
                 }
 

--- a/MtconnectCore/Standard/Documents/Streams/Component.cs
+++ b/MtconnectCore/Standard/Documents/Streams/Component.cs
@@ -12,69 +12,46 @@ namespace MtconnectCore.Standard.Documents.Streams
 {
     public class Component : MtconnectNode
     {
-        /// <summary>
-        /// Collected from the componentId attribute. Refer to Part 3 Streams - 4.3.2
-        /// 
-        /// Occurance: 1
-        /// </summary>
+        private const string MODEL_BROWSER_URL = "https://model.mtconnect.org/#Structure__EAID_9057AAF9_4687_42be_BD2B_E2F18DF049DC";
+
+        /// <inheritdoc cref="ComponentAttributes.COMPONENT_ID"/>
         [MtconnectNodeAttribute(ComponentAttributes.COMPONENT_ID)]
         public string ComponentId { get; set; }
 
-        /// <summary>
-        /// Collected from the name attribute. Refer to Part 3 Streams - 4.3.2
-        /// 
-        /// Occurance: 0..1
-        /// </summary>
+        /// <inheritdoc cref="ComponentAttributes.NAME"/>
         [MtconnectNodeAttribute(ComponentAttributes.NAME)]
         public string Name { get; set; }
 
-        /// <summary>
-        /// Collected from the nativeName attribute. Refer to Part 3 Streams - 4.3.2
-        /// 
-        /// Occurance: 0..1
-        /// </summary>
+        /// <inheritdoc cref="ComponentAttributes.NATIVE_NAME"/>
         [MtconnectNodeAttribute(ComponentAttributes.NATIVE_NAME)]
         public string NativeName { get; set; }
 
-        /// <summary>
-        /// Collected from the component attribute. Refer to Part 3 Streams - 4.3.2
-        /// 
-        /// Occurance: 1
-        /// </summary>
+        /// <inheritdoc cref="ComponentAttributes.COMPONENT"/>
         [MtconnectNodeAttribute(ComponentAttributes.COMPONENT)]
         public string ComponentReference { get; set; }
 
-        /// <summary>
-        /// Collected from the uuid attribute. Refer to Part 3 Streams - 4.3.2
-        /// 
-        /// Occurance: 0..1
-        /// </summary>
+        /// <inheritdoc cref="ComponentAttributes.UUID"/>
         [MtconnectNodeAttribute(ComponentAttributes.UUID)]
         public string Uuid { get; set; }
 
         private List<Sample> _samples = new List<Sample>();
         /// <summary>
-        /// Collected from Sample elements. Refer to Part 3 Streams - 4.3.3
-        /// 
-        /// Occurance: 0..1
+        /// Samples groups one or more Sample entities. See Section Sample.
         /// </summary>
         [MtconnectNodeElements("Samples/*", nameof(TryAddSample), XmlNamespace = Constants.DEFAULT_XML_NAMESPACE)]
         public ICollection<Sample> Samples => _samples;
 
         private List<Event> _events = new List<Event>();
         /// <summary>
-        /// Collected from Event elements. Refer to Part 3 Streams - 4.3.3
-        /// 
-        /// Occurance: 0..1
+        /// Events groups one or more Event entities. See Section Event.
         /// </summary>
         [MtconnectNodeElements("Events/*", nameof(TryAddEvent), XmlNamespace = Constants.DEFAULT_XML_NAMESPACE)]
         public ICollection<Event> Events => _events;
 
         private List<Condition> _conditions = new List<Condition>();
         /// <summary>
-        /// Collected from Sample elements. Refer to Part 3 Streams - 4.3.3
-        /// 
-        /// Occurance: 0..1
+        /// Conditions groups one or more Condition entities. See Section Condition.
+        /// Note: In the XML representation, Conditions MUST appear as Condition element in the MTConnectStreams Response Document.
         /// </summary>
         [MtconnectNodeElements("Condition/*", nameof(TryAddCondition), XmlNamespace = Constants.DEFAULT_XML_NAMESPACE)]
         public ICollection<Condition> Conditions => _conditions;
@@ -146,7 +123,7 @@ namespace MtconnectCore.Standard.Documents.Streams
         public bool TryAddCondition(XmlNode xNode, XmlNamespaceManager nsmgr, out Condition condition) => base.TryAdd<Condition>(xNode, nsmgr, ref _conditions, out condition);
 
 
-        [MtconnectVersionApplicability(MtconnectVersions.V_1_0_1, "Part 3 Section 3.4")]
+        [MtconnectVersionApplicability(MtconnectVersions.V_1_0_1, MODEL_BROWSER_URL)]
         private bool validateComponentId(out ICollection<MtconnectValidationException> validationErrors)
         {
             validationErrors = new List<MtconnectValidationException>();
@@ -160,7 +137,7 @@ namespace MtconnectCore.Standard.Documents.Streams
             return !validationErrors.Any(o => o.Severity == ValidationSeverity.ERROR);
         }
 
-        [MtconnectVersionApplicability(MtconnectVersions.V_1_0_1, "Part 3 Section 3.4")]
+        [MtconnectVersionApplicability(MtconnectVersions.V_1_0_1, MODEL_BROWSER_URL)]
         private bool validateComponentReference(out ICollection<MtconnectValidationException> validationErrors)
         {
             validationErrors = new List<MtconnectValidationException>();
@@ -174,8 +151,8 @@ namespace MtconnectCore.Standard.Documents.Streams
             return !validationErrors.Any(o => o.Severity == ValidationSeverity.ERROR);
         }
 
-        [MtconnectVersionApplicability(MtconnectVersions.V_1_0_1, "Part 3 Section 3.4", MtconnectVersions.V_1_2_0)]
-        private bool validateName(out ICollection<MtconnectValidationException> validationErrors)
+        [MtconnectVersionApplicability(MtconnectVersions.V_1_0_1, MODEL_BROWSER_URL, MtconnectVersions.V_1_2_0)]
+        private bool validateNameRequired_Deprecated(out ICollection<MtconnectValidationException> validationErrors)
         {
             validationErrors = new List<MtconnectValidationException>();
             if (string.IsNullOrEmpty(Name)) {
@@ -183,6 +160,17 @@ namespace MtconnectCore.Standard.Documents.Streams
                     ValidationSeverity.ERROR,
                     $"Component MUST include a 'name' attribute.",
                     SourceNode));
+            }
+            return !validationErrors.Any(o => o.Severity == ValidationSeverity.ERROR);
+        }
+
+        [MtconnectVersionApplicability(MtconnectVersions.V_1_3_0, MODEL_BROWSER_URL)]
+        private bool validateContents(out ICollection<MtconnectValidationException> validationErrors)
+        {
+            validationErrors = new List<MtconnectValidationException>();
+            if (Events.Count <= 0 && Samples.Count <= 0 && Conditions.Count <= 0)
+            {
+                validationErrors.Add(new MtconnectValidationException(ValidationSeverity.ERROR, "ComponentStream MUST have at least one of Event, Sample, or Condition.", SourceNode));
             }
             return !validationErrors.Any(o => o.Severity == ValidationSeverity.ERROR);
         }

--- a/MtconnectCore/Standard/Documents/Streams/Condition.cs
+++ b/MtconnectCore/Standard/Documents/Streams/Condition.cs
@@ -14,41 +14,29 @@ namespace MtconnectCore.Standard.Documents.Streams
 {
     public class Condition : Value
     {
+        private const string MODEL_BROWSER_URL = "https://model.mtconnect.org/#Structure___19_0_3_45f01b9_1579566531113_85883_25726";
+
         public override CategoryTypes Category => CategoryTypes.CONDITION;
 
-        /// <summary>
-        /// Collected from the nativeCode attribute. Refer to Part 3 Streams - 5.8.3
-        /// 
-        /// Occurance: 0..1
-        /// </summary>
+        /// <inheritdoc cref="ConditionAttributes.NATIVE_CODE"/>
         [MtconnectNodeAttribute(ConditionAttributes.NATIVE_CODE)]
         public string NativeCode { get; set; }
 
-        /// <summary>
-        /// Collected from the nativeSeverity attribute. Refer to Part 3 Streams - 5.8.3
-        /// 
-        /// Occurance: 0..1
-        /// </summary>
+        /// <inheritdoc cref="ConditionAttributes.NATIVE_SEVERITY"/>
         [MtconnectNodeAttribute(ConditionAttributes.NATIVE_SEVERITY)]
         public string NativeSeverity { get; set; }
 
-        /// <summary>
-        /// Collected from the qualifier attribute. Refer to Part 3 Streams - 5.8.3
-        /// 
-        /// Occurance: 0..1
-        /// </summary>
-        // TODO: Validate Enum
+        /// <inheritdoc cref="ConditionAttributes.QUALIFIER"/>
         [MtconnectNodeAttribute(ConditionAttributes.QUALIFIER)]
         public string Qualifier { get; set; }
 
-        /// <summary>
-        /// Collected from the statistic attribute. Refer to Part 3 Streams - 5.8.3
-        /// 
-        /// Occurance: 0..1
-        /// </summary>
-        // TODO: Validate Enum
+        /// <inheritdoc cref="ConditionAttributes.STATISTIC"/>
         [MtconnectNodeAttribute(ConditionAttributes.STATISTIC)]
         public string Statistic { get; set; }
+
+        /// <inheritdoc cref="ConditionAttributes.CONDITION_ID"/>
+        [MtconnectNodeAttribute(ConditionAttributes.CONDITION_ID)]
+        public string ConditionId { get; set; }
 
         /// <summary>
         /// Collected from the xs:lang attribute. Refer to Part 3 Streams - 5.8.3
@@ -86,7 +74,7 @@ namespace MtconnectCore.Standard.Documents.Streams
             }
         }
 
-        [MtconnectVersionApplicability(MtconnectVersions.V_1_1_0, "See model.mtconnect.org/Observation Information Model/Condition")]
+        [MtconnectVersionApplicability(MtconnectVersions.V_1_1_0, MODEL_BROWSER_URL)]
         private bool validateType(out ICollection<MtconnectValidationException> validationErrors) {
             validationErrors = new List<MtconnectValidationException>();
             if (string.IsNullOrEmpty(Type))
@@ -111,13 +99,13 @@ namespace MtconnectCore.Standard.Documents.Streams
             {
                 validationErrors.Add(new MtconnectValidationException(
                     ValidationSeverity.WARNING,
-                    $"Condition type of '{Type}' is not supported in version '{MtconnectVersion}' of the MTConnect Standard.",
+                    $"Condition 'type' of '{Type}' is not supported in version '{MtconnectVersion}' of the MTConnect Standard.",
                     SourceNode));
             }
             return !validationErrors.Any(o => o.Severity == ValidationSeverity.ERROR);
         }
 
-        [MtconnectVersionApplicability(MtconnectVersions.V_1_2_0, "See model.mtconnect.org/Observation Information Model/Condition")]
+        [MtconnectVersionApplicability(MtconnectVersions.V_1_2_0, MODEL_BROWSER_URL)]
         protected bool validateStatistic(out ICollection<MtconnectValidationException> validationErrors)
         {
             validationErrors = new List<MtconnectValidationException>();
@@ -134,7 +122,7 @@ namespace MtconnectCore.Standard.Documents.Streams
             return !validationErrors.Any(o => o.Severity == ValidationSeverity.ERROR);
         }
 
-        [MtconnectVersionApplicability(MtconnectVersions.V_1_1_0, "See model.mtconnect.org/Observation Information Model/Condition")]
+        [MtconnectVersionApplicability(MtconnectVersions.V_1_1_0, MODEL_BROWSER_URL)]
         protected bool validateQualifier(out ICollection<MtconnectValidationException> validationErrors)
         {
             validationErrors = new List<MtconnectValidationException>();
@@ -151,8 +139,21 @@ namespace MtconnectCore.Standard.Documents.Streams
             return !validationErrors.Any(o => o.Severity == ValidationSeverity.ERROR);
         }
 
+        [MtconnectVersionApplicability(MtconnectVersions.V_2_3_0, MODEL_BROWSER_URL)]
+        protected bool validateConditionId(out ICollection<MtconnectValidationException> validationErrors)
+        {
+            validationErrors = new List<MtconnectValidationException>();
+            if (string.IsNullOrEmpty(ConditionId))
+            {
+                validationErrors.Add(new MtconnectValidationException(
+                    ValidationSeverity.ERROR,
+                    $"Condition MUST include 'conditionId' attribute.",
+                    SourceNode));
+            }
+            return !validationErrors.Any(o => o.Severity == ValidationSeverity.ERROR);
+        }
 
-        [MtconnectVersionApplicability(MtconnectVersions.V_1_0_1, "See model.mtconnect.org/Observation Information Model/Sample")]
+        [MtconnectVersionApplicability(MtconnectVersions.V_1_0_1, MODEL_BROWSER_URL)]
         protected override bool validateNode(out ICollection<MtconnectValidationException> validationErrors)
             => base.validateNode(out validationErrors);
 

--- a/MtconnectCore/Standard/Documents/Streams/Device.cs
+++ b/MtconnectCore/Standard/Documents/Streams/Device.cs
@@ -13,19 +13,13 @@ namespace MtconnectCore.Standard.Documents.Streams
 {
     public class Device : MtconnectNode
     {
-        /// <summary>
-        /// Collected from the name attribute. Refer to Part 3 Streams - 4.2.2
-        /// 
-        /// Occurance: 1
-        /// </summary>
+        private const string MODEL_BROWSER_URL = "https://model.mtconnect.org/#Structure___19_0_3_68e0225_1620240839406_285612_1596";
+
+        /// <inheritdoc cref="DeviceAttributes.NAME"/>
         [MtconnectNodeAttribute(DeviceAttributes.NAME)]
         public string Name { get; set; }
 
-        /// <summary>
-        /// Collected from the uuid attribute. Refer to Part 3 Streams - 4.2.2
-        /// 
-        /// Occurance: 1
-        /// </summary>
+        /// <inheritdoc cref="DeviceAttributes.UUID"/>
         [MtconnectNodeAttribute(DeviceAttributes.UUID)]
         public string Uuid { get; set; }
 
@@ -46,8 +40,7 @@ namespace MtconnectCore.Standard.Documents.Streams
 
         public bool TryAddComponent(XmlNode xNode, XmlNamespaceManager nsmgr, out Component component) => base.TryAdd<Component>(xNode, nsmgr, ref _components, out component);
 
-
-        [MtconnectVersionApplicability(MtconnectVersions.V_1_0_1, "Part 2 Section 3.3.1")]
+        [MtconnectVersionApplicability(MtconnectVersions.V_1_0_1, MODEL_BROWSER_URL)]
         private bool validateName(out ICollection<MtconnectValidationException> validationErrors)
         {
             validationErrors = new List<MtconnectValidationException>();
@@ -61,7 +54,7 @@ namespace MtconnectCore.Standard.Documents.Streams
             return !validationErrors.Any(o => o.Severity == ValidationSeverity.ERROR);
         }
 
-        [MtconnectVersionApplicability(MtconnectVersions.V_1_0_1, "Part 3 Section 3.3.1")]
+        [MtconnectVersionApplicability(MtconnectVersions.V_1_0_1, MODEL_BROWSER_URL)]
         private bool validateUuid(out ICollection<MtconnectValidationException> validationErrors)
         {
             validationErrors = new List<MtconnectValidationException>();

--- a/MtconnectCore/Standard/Documents/Streams/Event.cs
+++ b/MtconnectCore/Standard/Documents/Streams/Event.cs
@@ -88,7 +88,7 @@ namespace MtconnectCore.Standard.Documents.Streams
                 {
                     validationErrors.Add(new MtconnectValidationException(
                         ValidationSeverity.ERROR,
-                        $"Observation resetTriggered of '{ResetTriggered}' is not defined in the MTConnect Standard in version '{MtconnectVersion}'.",
+                        $"Observation 'resetTriggered' of '{ResetTriggered}' is not defined in the MTConnect Standard in version '{MtconnectVersion}'.",
                             SourceNode));
                 }
             }

--- a/MtconnectCore/Standard/Documents/Streams/Sample.cs
+++ b/MtconnectCore/Standard/Documents/Streams/Sample.cs
@@ -14,37 +14,23 @@ namespace MtconnectCore.Standard.Documents.Streams
 {
     public class Sample : Value
     {
+        private const string MODEL_BROWSER_URL = "https://model.mtconnect.org/#Structure___19_0_3_45f01b9_1579566531116_175117_25733";
+
         public override CategoryTypes Category => CategoryTypes.SAMPLE;
 
-        /// <summary>
-        /// Collected from the sampleRate attribute. Refer to Part 3 Streams - 5.3.2
-        /// 
-        /// Occurance: 0..1
-        /// </summary>
+        /// <inheritdoc cref="SampleAttributes.SAMPLE_RATE"/>
         [MtconnectNodeAttribute(SampleAttributes.SAMPLE_RATE)]
         public float? SampleRate { get; set; }
 
-        /// <summary>
-        /// Collected from the statistic attribute. Refer to Part 3 Streams - 5.3.2
-        /// 
-        /// Occurance: 0..1
-        /// </summary>
+        /// <inheritdoc cref="SampleAttributes.STATISTIC"/>
         [MtconnectNodeAttribute(SampleAttributes.STATISTIC)]
         public string Statistic { get; set; }
 
-        /// <summary>
-        /// Collected from the duration attribute. Refer to Part 3 Streams - 5.3.2
-        /// 
-        /// Occurance: 0..1
-        /// </summary>
+        /// <inheritdoc cref="SampleAttributes.DURATION"/>
         [MtconnectNodeAttribute(SampleAttributes.DURATION)]
         public double? Duration { get; set; }
 
-        /// <summary>
-        /// Collected from the resetTriggered attribute. Refer to Part 3 Streams - 5.3.2
-        /// 
-        /// Occurance: 0..1
-        /// </summary>
+        /// <inheritdoc cref="SampleAttributes.RESET_TRIGGERED"/>
         [MtconnectNodeAttribute(SampleAttributes.RESET_TRIGGERED)]
         public string ResetTriggered { get; set; }
 
@@ -62,6 +48,7 @@ namespace MtconnectCore.Standard.Documents.Streams
             }
         }
 
+        /// <inheritdoc cref="SampleAttributes.SAMPLE_COUNT"/>
         [MtconnectNodeAttribute(SampleAttributes.SAMPLE_COUNT)]
         public int? SampleCount { get; set; }
 
@@ -71,7 +58,7 @@ namespace MtconnectCore.Standard.Documents.Streams
         /// <inheritdoc/>
         public Sample(XmlNode xNode, XmlNamespaceManager nsmgr, MtconnectVersions version) : base(xNode, nsmgr, version) { }
 
-        [MtconnectVersionApplicability(MtconnectVersions.V_1_3_0, "See model.mtconnect.org/Observation Information Model/Sample")]
+        [MtconnectVersionApplicability(MtconnectVersions.V_1_3_0, MODEL_BROWSER_URL)]
         protected bool validateTimeSeriesCount(out ICollection<MtconnectValidationException> validationErrors) {
             validationErrors = new List<MtconnectValidationException>();
             string[] timeSeriesValues = SourceNode.InnerText.Split(new[] { " " }, System.StringSplitOptions.RemoveEmptyEntries);
@@ -85,7 +72,7 @@ namespace MtconnectCore.Standard.Documents.Streams
             return !validationErrors.Any(o => o.Severity == ValidationSeverity.ERROR);
         }
 
-        [MtconnectVersionApplicability(MtconnectVersions.V_1_2_0, "See model.mtconnect.org/Observation Information Model/Sample")]
+        [MtconnectVersionApplicability(MtconnectVersions.V_1_2_0, MODEL_BROWSER_URL)]
         protected bool validateDuration(out ICollection<MtconnectValidationException> validationErrors)
         {
             validationErrors = new List<MtconnectValidationException>();
@@ -93,13 +80,13 @@ namespace MtconnectCore.Standard.Documents.Streams
             {
                 validationErrors.Add(new MtconnectValidationException(
                     ValidationSeverity.ERROR,
-                    $"'duration' MUST be provided when the 'statistic' attribute is present on a SAMPLE.",
+                    $"Observation MUST include 'duration' attribute when the 'statistic' attribute is present.",
                     SourceNode));
             }
             return !validationErrors.Any(o => o.Severity == ValidationSeverity.ERROR);
         }
 
-        [MtconnectVersionApplicability(MtconnectVersions.V_1_2_0, "See model.mtconnect.org/Observation Information Model/Sample")]
+        [MtconnectVersionApplicability(MtconnectVersions.V_1_2_0, MODEL_BROWSER_URL)]
         protected bool validateStatistic(out ICollection<MtconnectValidationException> validationErrors)
         {
             validationErrors = new List<MtconnectValidationException>();
@@ -116,7 +103,7 @@ namespace MtconnectCore.Standard.Documents.Streams
             return !validationErrors.Any(o => o.Severity == ValidationSeverity.ERROR);
         }
 
-        [MtconnectVersionApplicability(MtconnectVersions.V_1_4_0, "See model.mtconnect.org/Observation Information Model/Sample")]
+        [MtconnectVersionApplicability(MtconnectVersions.V_1_4_0, MODEL_BROWSER_URL)]
         protected bool validateResetTriggered(out ICollection<MtconnectValidationException> validationErrors)
         {
             validationErrors = new List<MtconnectValidationException>();
@@ -126,18 +113,18 @@ namespace MtconnectCore.Standard.Documents.Streams
                 {
                     validationErrors.Add(new MtconnectValidationException(
                         ValidationSeverity.ERROR,
-                        $"Observation resetTriggered of '{ResetTriggered}' is not defined in the MTConnect Standard in version '{MtconnectVersion}'.",
+                        $"Observation 'resetTriggered' of '{ResetTriggered}' is not defined in the MTConnect Standard in version '{MtconnectVersion}'.",
                             SourceNode));
                 }
             }
             return !validationErrors.Any(o => o.Severity == ValidationSeverity.ERROR);
         }
 
-        [MtconnectVersionApplicability(MtconnectVersions.V_1_0_1, "See model.mtconnect.org/Observation Information Model/Sample")]
+        [MtconnectVersionApplicability(MtconnectVersions.V_1_0_1, MODEL_BROWSER_URL)]
         protected override bool validateNode(out ICollection<MtconnectValidationException> validationErrors)
             => base.validateNode(out validationErrors);
 
-        [MtconnectVersionApplicability(MtconnectVersions.V_1_0_1, "See model.mtconnect.org/Observation Information Model/Sample")]
+        [MtconnectVersionApplicability(MtconnectVersions.V_1_0_1, MODEL_BROWSER_URL)]
         protected override bool validateValue(out ICollection<MtconnectValidationException> validationErrors)
         {
             validationErrors = new List<MtconnectValidationException>();

--- a/MtconnectCoreExample/MtconnectCoreExample.csproj
+++ b/MtconnectCoreExample/MtconnectCoreExample.csproj
@@ -17,7 +17,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\MtconnectCore\MtconnectCore.csproj" />
+    <ProjectReference Include="..\MtconnectCore\MtconnectCore.csproj">
+      <Private>True</Private>
+    </ProjectReference>
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
 - Fixed version identification when XML namespaces are not properly defined
 - Added automatic inclusion of XML namespaces to allow XPath to work when XML not properly formatted
 - Added current and upcoming versions of MTConnect to Enum
 - Added validation constraints
   - Device Components minimum child node requirements
   - Device DataItem improved support for detecting extensions to Types, SubTypes, and Units
   - Device DataItem validation of nativeScale
   - Device DataItem validation of sampleRate
   - Device DataItem validation of significantDigits
   - Device DataItem validation of deprecated coordinateSystem
   - Device validation of mtconnectVersion
   - Device validation of hash
   - Device validation of deprecated ISO 841 Class
   - Expanded Device validation of DataItem and Component Ids, Uuids, and Names
   - Component Stream minimum child node requirements
   - Condition validation of conditionId
   - Observation support for extended units
 - Added validation error when XML namespaces have to be added